### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is the **OpenTelemetry Python Contrib / LoongSuite** monorepo: a collection of
+Python instrumentation/exporter/propagator libraries (published as PyPI packages). There is
+**no long-running application server**; "running the product" means exercising the
+instrumentation via the test suites or a small instrumented script.
+
+### Toolchain / how things are wired
+- Package/dev manager is **`uv`** with a workspace (`[tool.uv.workspace]` in `pyproject.toml`).
+  `uv sync` builds a single dev virtualenv at `.venv/` containing every workspace package plus
+  the dev tools (`tox`, `tox-uv`, `pre-commit`). The update script runs `uv sync`.
+- Test/lint orchestration is **`tox`**. Two configs exist:
+  - `tox.ini` — upstream OTel packages (e.g. `tox -e py312-test-instrumentation-requests`).
+  - `tox-loongsuite.ini` — LoongSuite packages; must pass `-c tox-loongsuite.ini`
+    (e.g. `tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-langchain-latest`).
+- Prefer the venv binaries: `.venv/bin/tox`, `.venv/bin/python`. `uv` installs to
+  `~/.local/bin` (already on PATH for the update script; add it to PATH in interactive shells
+  if `uv` isn't found).
+
+### Common commands
+- Lint (runs pre-commit: ruff lint, ruff format, uv-lock, rstcheck): `.venv/bin/tox -e ruff`
+- List envs: `.venv/bin/tox -l` / `.venv/bin/tox -c tox-loongsuite.ini -l`
+- Run one package's tests: `.venv/bin/tox -e py312-test-instrumentation-<pkg>`
+- `tox -e <pkg>` (no python prefix) and a bare `tox` run the full matrix across many Python
+  versions — slow and needs interpreters that may not be installed. Scope to a `py312-...` env.
+
+### Non-obvious gotchas
+- **System build libs are required** for `uv sync` to compile native deps; they are installed
+  outside the update script (already baked into the VM): `build-essential pkg-config libpq-dev
+  default-libmysqlclient-dev librdkafka-dev libsnappy-dev python3-dev`. If `uv sync` fails with
+  `pg_config not found`, `Python.h: No such file`, etc., re-install the matching `-dev` package.
+- **Auto-instrumentation CLI (`opentelemetry-instrument`) currently breaks in the `uv sync`
+  venv.** `pyproject.toml` pins `opentelemetry-api/sdk/semantic-conventions` to the upstream
+  core **`main` branch** (bleeding edge), which is ahead of what the bundled logging
+  instrumentor expects; the auto-instrumentation `sitecustomize` aborts with
+  `LogRecord.__init__() got an unexpected keyword argument 'context'` and emits no telemetry.
+  For a quick end-to-end smoke test, instrument **programmatically** instead (set up a
+  `TracerProvider` + `ConsoleSpanExporter`, then `RequestsInstrumentor().instrument()`), which
+  is also how the test suites run. The per-package `tox` envs are unaffected because they pin
+  the core repo via `CORE_REPO_SHA`.
+- `opentelemetry-instrument`/`opentelemetry-bootstrap` resolve the interpreter named `python`;
+  the VM only has `python3`. Pass an explicit interpreter path if you use those CLIs.
+- GenAI/LLM instrumentation tests use recorded **VCR cassettes**, so no live API keys are
+  needed for the default suites.
+- DB/broker integration tests under `tests/opentelemetry-docker-tests/` need the optional
+  Docker Compose stack (Postgres/MySQL/Mongo/Redis/Jaeger) and are not run by default.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this OpenTelemetry Python Contrib / LoongSuite instrumentation monorepo and documents it for future Cursor Cloud agents. No product code is changed.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section describing the `uv` + `tox` workflow, common commands, required system build libs, and non-obvious gotchas.

## Environment setup performed

- Installed `uv` and system build libs (`build-essential pkg-config libpq-dev default-libmysqlclient-dev librdkafka-dev libsnappy-dev python3-dev`) needed to compile native deps (psycopg2, mysqlclient, etc.).
- `uv sync` builds the dev virtualenv at `.venv/` (all workspace packages + `tox`/`tox-uv`/`pre-commit`).
- Update script (run on VM startup): installs `uv` if missing, then `uv sync`.

## Verification

| Check | Command | Result |
| --- | --- | --- |
| Lint | `.venv/bin/tox -e ruff` | ✅ ruff/format/uv-lock/rstcheck passed |
| Tests (upstream) | `.venv/bin/tox -e py312-test-instrumentation-requests` | ✅ 80 passed |
| Tests (LoongSuite) | `.venv/bin/tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-langchain-latest` | ✅ 150 passed |
| Hello-world | Programmatic `RequestsInstrumentor` + `ConsoleSpanExporter` GET example.com | ✅ CLIENT span emitted, `http.status_code: 200` |

### Hello-world span output
[hello_world_span.log](https://cursor.com/agents/bc-97f16836-870b-437d-8a70-1c7291054a61/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_span.log)

### Gotcha discovered
The `opentelemetry-instrument` auto-instrumentation CLI currently fails in the `uv sync` venv (core API/SDK pinned to upstream `main` is ahead of the bundled logging instrumentor: `LogRecord.__init__() got an unexpected keyword argument 'context'`). Per-package `tox` envs are unaffected (they pin `CORE_REPO_SHA`). Use programmatic instrumentation for quick smoke tests. Documented in `AGENTS.md`.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97f16836-870b-437d-8a70-1c7291054a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97f16836-870b-437d-8a70-1c7291054a61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

