### PR TITLE
fix(hermes): preserve provider response IDs

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Prefer provider-supplied OpenAI-compatible response IDs (including
+  DashScope-style `request_id` values) for `gen_ai.response.id` on Hermes LLM
+  spans, while retaining Hermes's response ID as a fallback.
+
 ## Version 0.7.0 (2026-07-03)
 
 ### Fixed

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prefer provider-supplied OpenAI-compatible response IDs (including
   DashScope-style `request_id` values) for `gen_ai.response.id` on Hermes LLM
   spans, while retaining Hermes's response ID as a fallback.
+- Align the Hermes plugin with the OpenTelemetry 1.39.1/0.60b1 release set used
+  by LoongSuite releases so its standard PyPI dependencies resolve consistently.
 
 ## Version 0.7.0 (2026-07-03)
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/pyproject.toml
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/pyproject.toml
@@ -24,11 +24,11 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "opentelemetry-api >= 1.37.0, < 1.40",
-  "opentelemetry-instrumentation >= 0.60b1, < 0.61",
-  "opentelemetry-instrumentation-threading >= 0.60b1, < 0.61",
-  "opentelemetry-sdk >= 1.37.0, < 1.40",
-  "opentelemetry-semantic-conventions >= 0.60b1, < 0.61",
+  "opentelemetry-api ~= 1.39.1",
+  "opentelemetry-instrumentation ~= 0.60b1",
+  "opentelemetry-instrumentation-threading ~= 0.60b1",
+  "opentelemetry-sdk ~= 1.39.1",
+  "opentelemetry-semantic-conventions ~= 0.60b1",
   "opentelemetry-util-genai",
   "wrapt >= 1.0.0, < 2.0.0",
 ]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/helpers.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/helpers.py
@@ -35,6 +35,7 @@ from opentelemetry.util.genai.extended_types import (
     InvokeAgentInvocation,
     ReactStepInvocation,
 )
+from opentelemetry.util.genai.response_id import resolve_response_id
 from opentelemetry.util.genai.types import (
     FunctionToolDefinition,
     GenericToolDefinition,
@@ -67,38 +68,6 @@ def obj_get(value: Any, field: str, default: Any = None) -> Any:
     if isinstance(value, dict):
         return value.get(field, default)
     return getattr(value, field, default)
-
-
-def response_identifier(
-    value: Any,
-    *,
-    fields: tuple[str, ...] = (
-        "id",
-        "request_id",
-        "response_id",
-        "_request_id",
-    ),
-) -> str | None:
-    """Return a normalized provider/framework response identifier.
-
-    OpenAI-compatible providers expose ``id`` while native DashScope-style
-    responses commonly call the same correlation value ``request_id``.  Keep
-    the extraction intentionally narrow so unrelated object identifiers are
-    never promoted to ``gen_ai.response.id``.
-    """
-
-    if isinstance(value, str):
-        normalized_value = value.strip()
-        return normalized_value or None
-
-    for field in fields:
-        candidate = obj_get(value, field)
-        if not isinstance(candidate, (str, int)):
-            continue
-        normalized = str(candidate).strip()
-        if normalized:
-            return normalized
-    return None
 
 
 def _normalize_platform(value: Any) -> str:
@@ -715,17 +684,10 @@ def update_llm_invocation_from_response(
     else:
         invocation.response_model_name = invocation.request_model
 
-    # Prefer the ID captured from the provider SDK stream. Hermes currently
-    # synthesizes ``stream-*`` IDs while aggregating OpenAI-compatible chunks,
-    # so the final framework response is only a fallback. Native-style
-    # ``request_id`` fields are checked before the framework ``id`` for the
-    # same reason.
-    response_id = response_identifier(
+    response_id = resolve_response_id(
         provider_response_id,
-        fields=("id",),
-    ) or response_identifier(
         response,
-        fields=("request_id", "id", "response_id", "_request_id"),
+        framework_fields=("request_id", "id", "response_id"),
     )
     if response_id:
         invocation.response_id = response_id

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/helpers.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/helpers.py
@@ -69,6 +69,38 @@ def obj_get(value: Any, field: str, default: Any = None) -> Any:
     return getattr(value, field, default)
 
 
+def response_identifier(
+    value: Any,
+    *,
+    fields: tuple[str, ...] = (
+        "id",
+        "request_id",
+        "response_id",
+        "_request_id",
+    ),
+) -> str | None:
+    """Return a normalized provider/framework response identifier.
+
+    OpenAI-compatible providers expose ``id`` while native DashScope-style
+    responses commonly call the same correlation value ``request_id``.  Keep
+    the extraction intentionally narrow so unrelated object identifiers are
+    never promoted to ``gen_ai.response.id``.
+    """
+
+    if isinstance(value, str):
+        normalized_value = value.strip()
+        return normalized_value or None
+
+    for field in fields:
+        candidate = obj_get(value, field)
+        if not isinstance(candidate, (str, int)):
+            continue
+        normalized = str(candidate).strip()
+        if normalized:
+            return normalized
+    return None
+
+
 def _normalize_platform(value: Any) -> str:
     platform = getattr(value, "value", value)
     return str(platform or "").strip().lower()
@@ -674,6 +706,8 @@ def update_llm_invocation_from_response(
     invocation: LLMInvocation,
     instance: Any,
     response: Any,
+    *,
+    provider_response_id: str | None = None,
 ) -> tuple[int, int, int]:
     response_model = getattr(response, "model", None)
     if response_model:
@@ -681,7 +715,18 @@ def update_llm_invocation_from_response(
     else:
         invocation.response_model_name = invocation.request_model
 
-    response_id = getattr(response, "id", None)
+    # Prefer the ID captured from the provider SDK stream. Hermes currently
+    # synthesizes ``stream-*`` IDs while aggregating OpenAI-compatible chunks,
+    # so the final framework response is only a fallback. Native-style
+    # ``request_id`` fields are checked before the framework ``id`` for the
+    # same reason.
+    response_id = response_identifier(
+        provider_response_id,
+        fields=("id",),
+    ) or response_identifier(
+        response,
+        fields=("request_id", "id", "response_id", "_request_id"),
+    )
     if response_id:
         invocation.response_id = response_id
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/instrumentor.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/instrumentor.py
@@ -29,6 +29,7 @@ from opentelemetry.util.genai.extended_handler import ExtendedTelemetryHandler
 from .metrics import HermesMetrics
 from .wrappers import (
     LLMCallWrapper,
+    ProviderClientWrapper,
     RunConversationWrapper,
     ToolBatchWrapper,
     ToolCallWrapper,
@@ -129,6 +130,11 @@ class HermesAgentInstrumentor(BaseInstrumentor):
         )
         _safe_wrap_function_wrapper(
             "run_agent",
+            "AIAgent._create_request_openai_client",
+            ProviderClientWrapper(),
+        )
+        _safe_wrap_function_wrapper(
+            "run_agent",
             "AIAgent._invoke_tool",
             ToolCallWrapper(handler),
         )
@@ -180,6 +186,7 @@ class HermesAgentInstrumentor(BaseInstrumentor):
         _safe_unwrap(ai_agent, "run_conversation")
         _safe_unwrap(ai_agent, "_interruptible_api_call")
         _safe_unwrap(ai_agent, "_interruptible_streaming_api_call")
+        _safe_unwrap(ai_agent, "_create_request_openai_client")
         _safe_unwrap(ai_agent, "_invoke_tool")
         _safe_unwrap(ai_agent, "_execute_tool_calls")
         _safe_unwrap(model_tools, "handle_function_call")

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/wrappers.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/wrappers.py
@@ -74,6 +74,7 @@ class _ProviderResponseAttempt:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._response_id: str | None = None
+        self._response_id_priority = 0
 
     @property
     def response_id(self) -> str | None:
@@ -81,15 +82,22 @@ class _ProviderResponseAttempt:
             return self._response_id
 
     def record(self, value: Any) -> None:
-        response_id = extract_response_id(
-            value,
-            fields=("request_id", "id", "response_id"),
-        )
+        # DashScope exposes its provider correlation ID as ``request_id`` even
+        # when an OpenAI-compatible completion ``id`` is also present.
+        response_id = extract_response_id(value, fields=("request_id",))
+        priority = 2
+        if response_id is None:
+            response_id = extract_response_id(
+                value,
+                fields=("id", "response_id"),
+            )
+            priority = 1
         if response_id is None:
             return
         with self._lock:
-            if self._response_id is None:
+            if priority > self._response_id_priority:
                 self._response_id = response_id
+                self._response_id_priority = priority
 
 
 class _ProviderResponseIdCapture:

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/wrappers.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/wrappers.py
@@ -17,6 +17,8 @@
 from __future__ import annotations
 
 import contextvars
+import functools
+import threading
 import timeit
 from collections.abc import Mapping
 from contextlib import suppress
@@ -37,6 +39,7 @@ from .helpers import (
     push_state,
     reset_state,
     resolve_entry_platform,
+    response_identifier,
     start_step,
     state,
     step_finish_reason,
@@ -59,6 +62,131 @@ _GENAI_SPAN_NAME_PREFIXES = (
     "embedding ",
     "embeddings ",
 )
+_PROVIDER_CREATE_WRAPPED = "_otel_hermes_response_id_capture_wrapped"
+_PROVIDER_ATTEMPT = threading.local()
+_MISSING_PROVIDER_ATTEMPT = object()
+
+
+class _ProviderResponseAttempt:
+    """Response-ID state for one provider SDK ``create`` attempt."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._response_id: str | None = None
+
+    @property
+    def response_id(self) -> str | None:
+        with self._lock:
+            return self._response_id
+
+    def record(self, value: Any) -> None:
+        response_id = response_identifier(value)
+        if response_id is None:
+            return
+        with self._lock:
+            if self._response_id is None:
+                self._response_id = response_id
+
+
+class _ProviderResponseIdCapture:
+    """Invocation-local pointer to the active provider attempt."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._attempt: _ProviderResponseAttempt | None = None
+
+    def adopt_current_attempt(self) -> None:
+        attempt = getattr(_PROVIDER_ATTEMPT, "value", None)
+        if attempt is None:
+            return
+        with self._lock:
+            self._attempt = attempt
+
+    @property
+    def response_id(self) -> str | None:
+        with self._lock:
+            attempt = self._attempt
+        return attempt.response_id if attempt is not None else None
+
+
+class _ProviderStreamProxy:
+    """Transparent iterator that observes provider chunks without changing them."""
+
+    def __init__(self, stream: Any, attempt: _ProviderResponseAttempt) -> None:
+        self._stream = stream
+        self._attempt = attempt
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        chunk = next(self._stream)
+        self._attempt.record(chunk)
+        return chunk
+
+    def __enter__(self):
+        enter = getattr(self._stream, "__enter__", None)
+        if enter is not None:
+            entered = enter()
+            if entered is not self._stream:
+                self._stream = entered
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        exit_method = getattr(self._stream, "__exit__", None)
+        if exit_method is None:
+            return False
+        return exit_method(exc_type, exc_value, traceback)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+
+def _wrap_provider_create(resource: Any) -> None:
+    if resource is None or getattr(resource, _PROVIDER_CREATE_WRAPPED, False):
+        return
+    create = getattr(resource, "create", None)
+    if not callable(create):
+        return
+
+    @functools.wraps(create)
+    def _capturing_create(*args, **kwargs):
+        attempt = _ProviderResponseAttempt()
+        _PROVIDER_ATTEMPT.value = attempt
+        response = create(*args, **kwargs)
+        attempt.record(response)
+
+        if (
+            kwargs.get("stream") is True
+            and not hasattr(response, "choices")
+            and hasattr(response, "__iter__")
+        ):
+            return _ProviderStreamProxy(response, attempt)
+        return response
+
+    try:
+        setattr(resource, "create", _capturing_create)
+        setattr(resource, _PROVIDER_CREATE_WRAPPED, True)
+    except (AttributeError, TypeError):
+        # A provider resource may use slots/read-only descriptors. Telemetry
+        # must never make the model call fail; the framework response remains
+        # available as the fallback ID in that case.
+        return
+
+
+class ProviderClientWrapper:
+    """Decorate Hermes request-local SDK clients for response-ID capture."""
+
+    def __call__(self, wrapped, instance, args, kwargs):
+        client = wrapped(*args, **kwargs)
+        resources = (
+            getattr(getattr(client, "chat", None), "completions", None),
+            getattr(client, "responses", None),
+            getattr(client, "completions", None),
+        )
+        for resource in resources:
+            _wrap_provider_create(resource)
+        return client
 
 
 def _resolve_handler(
@@ -307,16 +435,24 @@ class LLMCallWrapper:
 
         api_kwargs = args[0] if args else kwargs.get("api_kwargs", {})
         invocation = create_llm_invocation(instance, api_kwargs)
+        provider_response_capture = _ProviderResponseIdCapture()
         provider = invocation.provider or provider_name(instance)
         model = invocation.request_model or ""
         self._handler.start_llm(invocation)
         started_at = timeit.default_timer()
+        previous_provider_attempt = getattr(
+            _PROVIDER_ATTEMPT,
+            "value",
+            _MISSING_PROVIDER_ATTEMPT,
+        )
+        _PROVIDER_ATTEMPT.value = None
 
         try:
             if self._streaming:
                 original_first_delta = kwargs.get("on_first_delta")
 
                 def _wrapped_first_delta():
+                    provider_response_capture.adopt_current_attempt()
                     now = timeit.default_timer()
                     invocation.monotonic_first_token_s = now
                     if current_state["first_token_monotonic_s"] is None:
@@ -327,9 +463,15 @@ class LLMCallWrapper:
                 kwargs["on_first_delta"] = _wrapped_first_delta
 
             response = wrapped(*args, **kwargs)
+            # Covers direct/synchronous streaming implementations that iterate
+            # on the caller thread instead of Hermes's worker thread.
+            provider_response_capture.adopt_current_attempt()
             input_tokens, output_tokens, total_tokens = (
                 update_llm_invocation_from_response(
-                    invocation, instance, response
+                    invocation,
+                    instance,
+                    response,
+                    provider_response_id=provider_response_capture.response_id,
                 )
             )
 
@@ -379,6 +521,11 @@ class LLMCallWrapper:
             finish_step(instance, "error", exc=exc)
             raise
         finally:
+            if previous_provider_attempt is _MISSING_PROVIDER_ATTEMPT:
+                with suppress(AttributeError):
+                    del _PROVIDER_ATTEMPT.value
+            else:
+                _PROVIDER_ATTEMPT.value = previous_provider_attempt
             current_state["active_llm_depth"] = max(
                 0, current_state["active_llm_depth"] - 1
             )

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/wrappers.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/src/opentelemetry/instrumentation/hermes_agent/wrappers.py
@@ -26,6 +26,7 @@ from typing import Any
 
 from opentelemetry import trace as trace_api
 from opentelemetry.util.genai.extended_handler import ExtendedTelemetryHandler
+from opentelemetry.util.genai.response_id import extract_response_id
 from opentelemetry.util.genai.types import Error
 
 from .helpers import (
@@ -39,7 +40,6 @@ from .helpers import (
     push_state,
     reset_state,
     resolve_entry_platform,
-    response_identifier,
     start_step,
     state,
     step_finish_reason,
@@ -64,7 +64,8 @@ _GENAI_SPAN_NAME_PREFIXES = (
 )
 _PROVIDER_CREATE_WRAPPED = "_otel_hermes_response_id_capture_wrapped"
 _PROVIDER_ATTEMPT = threading.local()
-_MISSING_PROVIDER_ATTEMPT = object()
+_PROVIDER_CAPTURE = threading.local()
+_MISSING_THREAD_LOCAL = object()
 
 
 class _ProviderResponseAttempt:
@@ -80,7 +81,10 @@ class _ProviderResponseAttempt:
             return self._response_id
 
     def record(self, value: Any) -> None:
-        response_id = response_identifier(value)
+        response_id = extract_response_id(
+            value,
+            fields=("request_id", "id", "response_id"),
+        )
         if response_id is None:
             return
         with self._lock:
@@ -99,6 +103,10 @@ class _ProviderResponseIdCapture:
         attempt = getattr(_PROVIDER_ATTEMPT, "value", None)
         if attempt is None:
             return
+        _PROVIDER_CAPTURE.value = self
+        self.adopt(attempt)
+
+    def adopt(self, attempt: _ProviderResponseAttempt) -> None:
         with self._lock:
             self._attempt = attempt
 
@@ -143,16 +151,21 @@ class _ProviderStreamProxy:
 
 
 def _wrap_provider_create(resource: Any) -> None:
-    if resource is None or getattr(resource, _PROVIDER_CREATE_WRAPPED, False):
-        return
-    create = getattr(resource, "create", None)
-    if not callable(create):
+    create = (
+        getattr(resource, "create", None) if resource is not None else None
+    )
+    if not callable(create) or getattr(
+        create, _PROVIDER_CREATE_WRAPPED, False
+    ):
         return
 
     @functools.wraps(create)
     def _capturing_create(*args, **kwargs):
         attempt = _ProviderResponseAttempt()
         _PROVIDER_ATTEMPT.value = attempt
+        capture = getattr(_PROVIDER_CAPTURE, "value", None)
+        if capture is not None:
+            capture.adopt(attempt)
         response = create(*args, **kwargs)
         attempt.record(response)
 
@@ -164,9 +177,9 @@ def _wrap_provider_create(resource: Any) -> None:
             return _ProviderStreamProxy(response, attempt)
         return response
 
+    setattr(_capturing_create, _PROVIDER_CREATE_WRAPPED, True)
     try:
         setattr(resource, "create", _capturing_create)
-        setattr(resource, _PROVIDER_CREATE_WRAPPED, True)
     except (AttributeError, TypeError):
         # A provider resource may use slots/read-only descriptors. Telemetry
         # must never make the model call fail; the framework response remains
@@ -179,13 +192,9 @@ class ProviderClientWrapper:
 
     def __call__(self, wrapped, instance, args, kwargs):
         client = wrapped(*args, **kwargs)
-        resources = (
-            getattr(getattr(client, "chat", None), "completions", None),
-            getattr(client, "responses", None),
-            getattr(client, "completions", None),
+        _wrap_provider_create(
+            getattr(getattr(client, "chat", None), "completions", None)
         )
-        for resource in resources:
-            _wrap_provider_create(resource)
         return client
 
 
@@ -443,9 +452,15 @@ class LLMCallWrapper:
         previous_provider_attempt = getattr(
             _PROVIDER_ATTEMPT,
             "value",
-            _MISSING_PROVIDER_ATTEMPT,
+            _MISSING_THREAD_LOCAL,
+        )
+        previous_provider_capture = getattr(
+            _PROVIDER_CAPTURE,
+            "value",
+            _MISSING_THREAD_LOCAL,
         )
         _PROVIDER_ATTEMPT.value = None
+        _PROVIDER_CAPTURE.value = provider_response_capture
 
         try:
             if self._streaming:
@@ -521,11 +536,16 @@ class LLMCallWrapper:
             finish_step(instance, "error", exc=exc)
             raise
         finally:
-            if previous_provider_attempt is _MISSING_PROVIDER_ATTEMPT:
+            if previous_provider_attempt is _MISSING_THREAD_LOCAL:
                 with suppress(AttributeError):
                     del _PROVIDER_ATTEMPT.value
             else:
                 _PROVIDER_ATTEMPT.value = previous_provider_attempt
+            if previous_provider_capture is _MISSING_THREAD_LOCAL:
+                with suppress(AttributeError):
+                    del _PROVIDER_CAPTURE.value
+            else:
+                _PROVIDER_CAPTURE.value = previous_provider_capture
             current_state["active_llm_depth"] = max(
                 0, current_state["active_llm_depth"] - 1
             )

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/requirements.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/requirements.txt
@@ -19,11 +19,11 @@ pyyaml>=6.0
 openai>=1.0.0
 wrapt>=1.0.0,<2.0.0
 
-opentelemetry-api>=1.37.0,<1.40
-opentelemetry-sdk>=1.37.0,<1.40
-opentelemetry-instrumentation>=0.60b1,<0.61
-opentelemetry-instrumentation-threading>=0.60b1,<0.61
-opentelemetry-semantic-conventions>=0.60b1,<0.61
+opentelemetry-api==1.39.1
+opentelemetry-sdk==1.39.1
+opentelemetry-instrumentation==0.60b1
+opentelemetry-instrumentation-threading==0.60b1
+opentelemetry-semantic-conventions==0.60b1
 
 -e util/opentelemetry-util-genai
 -e instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_live_llm_calls.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_live_llm_calls.py
@@ -102,7 +102,10 @@ def test_sync_llm_call_records_single_llm_span_and_metric(
     assert llm_input_messages[0]["role"] in {"system", "user"}
     assert all("parts" in message for message in llm_input_messages)
     assert span.attributes["gen_ai.response.model"]
-    assert span.attributes["gen_ai.response.id"]
+    assert (
+        span.attributes["gen_ai.response.id"]
+        == "chatcmpl-16b2e5f0-ebac-9b6a-b1f8-6cdf99efa597"
+    )
     assert span.attributes["gen_ai.usage.input_tokens"] > 0
     assert span.attributes["gen_ai.usage.output_tokens"] > 0
     assert span.attributes["gen_ai.response.finish_reasons"]
@@ -169,6 +172,14 @@ def test_streaming_llm_call_records_ttft(
     assert len(llm_spans) == 1
     assert step_spans[0].attributes["gen_ai.react.finish_reason"] == "stop"
     assert llm_spans[0].attributes["gen_ai.response.time_to_first_token"] > 0
+    assert (
+        llm_spans[0].attributes["gen_ai.response.id"]
+        == "chatcmpl-2d34edbc-ab63-9129-944b-df41352dfa4b"
+    )
+    assert (
+        agent_spans[0].attributes["gen_ai.response.id"]
+        == "chatcmpl-2d34edbc-ab63-9129-944b-df41352dfa4b"
+    )
     assert agent_spans[0].attributes["gen_ai.response.time_to_first_token"] > 0
     assert agent_spans[0].parent is None
     _assert_parent(step_spans[0], agent_spans[0])

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
@@ -523,60 +523,20 @@ def test_streaming_request_id_from_usage_trailer_is_preserved(
     assert llm_span.attributes["gen_ai.response.id"] == "dashscope-request-456"
 
 
-def test_streaming_retry_uses_successful_provider_attempt_id(
+@pytest.mark.parametrize(
+    ("retry_response_id", "expected_response_id"),
+    [
+        ("chatcmpl-successful-attempt", "chatcmpl-successful-attempt"),
+        (None, "stream-retry-framework-fallback"),
+    ],
+)
+def test_streaming_retry_uses_only_final_provider_attempt(
     instrumentation_module,
     tracer_provider,
     meter_provider,
     span_exporter,
-):
-    runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
-    agent = _FakeAgent(session_id="session-provider-retry")
-    wrappers_module = importlib.import_module(
-        "opentelemetry.instrumentation.hermes_agent.wrappers"
-    )
-    provider_client_wrapper = wrappers_module.ProviderClientWrapper()
-    client = _provider_client(
-        [
-            iter([_stream_chunk("chatcmpl-failed-attempt")]),
-            iter([_stream_chunk("chatcmpl-successful-attempt")]),
-        ]
-    )
-
-    def streaming_call(_api_kwargs, *, on_first_delta):
-        request_client = provider_client_wrapper(
-            lambda: client,
-            agent,
-            (),
-            {},
-        )
-        for _chunk in request_client.chat.completions.create(stream=True):
-            on_first_delta()
-        for _chunk in request_client.chat.completions.create(stream=True):
-            on_first_delta()
-        return _response(
-            content="恢复成功",
-            response_id="stream-retry-framework-id",
-        )
-
-    runtime.streaming_llm_wrapper(
-        streaming_call,
-        agent,
-        ({"model": agent.model, "messages": []},),
-        {},
-    )
-
-    llm_span = _spans_by_kind(span_exporter, "LLM")[0]
-    assert (
-        llm_span.attributes["gen_ai.response.id"]
-        == "chatcmpl-successful-attempt"
-    )
-
-
-def test_streaming_retry_does_not_reuse_failed_provider_attempt_id(
-    instrumentation_module,
-    tracer_provider,
-    meter_provider,
-    span_exporter,
+    retry_response_id,
+    expected_response_id,
 ):
     runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
     agent = _FakeAgent(session_id="session-provider-retry-fallback")
@@ -587,21 +547,39 @@ def test_streaming_retry_does_not_reuse_failed_provider_attempt_id(
     client = _provider_client(
         [
             iter([_stream_chunk("chatcmpl-failed-attempt")]),
-            iter([_stream_chunk()]),
+            iter([_stream_chunk(retry_response_id)]),
         ]
     )
 
     def streaming_call(_api_kwargs, *, on_first_delta):
-        request_client = provider_client_wrapper(
-            lambda: client,
-            agent,
-            (),
-            {},
-        )
-        for _chunk in request_client.chat.completions.create(stream=True):
-            on_first_delta()
-        for _chunk in request_client.chat.completions.create(stream=True):
-            on_first_delta()
+        errors = []
+
+        def provider_worker():
+            try:
+                request_client = provider_client_wrapper(
+                    lambda: client,
+                    agent,
+                    (),
+                    {},
+                )
+                for _chunk in request_client.chat.completions.create(
+                    stream=True
+                ):
+                    # Hermes invokes this callback once for the whole logical
+                    # call, even when it starts another provider attempt.
+                    on_first_delta()
+                for _chunk in request_client.chat.completions.create(
+                    stream=True
+                ):
+                    pass
+            except BaseException as exc:  # pragma: no cover - defensive
+                errors.append(exc)
+
+        worker = threading.Thread(target=provider_worker)
+        worker.start()
+        worker.join(timeout=5)
+        assert not worker.is_alive()
+        assert errors == []
         return _response(
             content="恢复成功",
             response_id="stream-retry-framework-fallback",
@@ -615,10 +593,7 @@ def test_streaming_retry_does_not_reuse_failed_provider_attempt_id(
     )
 
     llm_span = _spans_by_kind(span_exporter, "LLM")[0]
-    assert (
-        llm_span.attributes["gen_ai.response.id"]
-        == "stream-retry-framework-fallback"
-    )
+    assert llm_span.attributes["gen_ai.response.id"] == expected_response_id
 
 
 def test_streaming_without_provider_id_falls_back_to_hermes_response_id(
@@ -690,6 +665,53 @@ def test_read_only_provider_resource_falls_back_without_breaking_call(
         llm_span.attributes["gen_ai.response.id"]
         == "stream-read-only-fallback"
     )
+
+
+def test_provider_error_is_reported_without_masking_original_exception(
+    instrumentation_module,
+    tracer_provider,
+    meter_provider,
+    span_exporter,
+):
+    runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
+    agent = _FakeAgent(session_id="session-provider-error")
+    wrappers_module = importlib.import_module(
+        "opentelemetry.instrumentation.hermes_agent.wrappers"
+    )
+    provider_client_wrapper = wrappers_module.ProviderClientWrapper()
+
+    class ProviderError(RuntimeError):
+        pass
+
+    class FailingResource:
+        @staticmethod
+        def create(**_kwargs):
+            raise ProviderError("provider unavailable")
+
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=FailingResource())
+    )
+
+    def streaming_call(_api_kwargs, *, on_first_delta):
+        del on_first_delta
+        request_client = provider_client_wrapper(
+            lambda: client,
+            agent,
+            (),
+            {},
+        )
+        return request_client.chat.completions.create(stream=True)
+
+    with pytest.raises(ProviderError, match="provider unavailable"):
+        runtime.streaming_llm_wrapper(
+            streaming_call,
+            agent,
+            ({"model": agent.model, "messages": []},),
+            {},
+        )
+
+    llm_span = _spans_by_kind(span_exporter, "LLM")[0]
+    assert llm_span.status.status_code == StatusCode.ERROR
 
 
 def test_provider_attempt_from_previous_call_does_not_leak(

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
@@ -512,7 +512,7 @@ def test_streaming_request_id_from_usage_trailer_is_preserved(
         [
             iter(
                 [
-                    _stream_chunk(),
+                    _stream_chunk("chatcmpl-chunk-456"),
                     _stream_chunk(request_id="dashscope-request-456"),
                 ]
             )

--- a/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py
@@ -141,6 +141,10 @@ def test_instrumentation_skips_missing_hermes_targets(
     )
 
     assert ("run_agent", "AIAgent.run_conversation") in wrapped_targets
+    assert (
+        "run_agent",
+        "AIAgent._create_request_openai_client",
+    ) in wrapped_targets
     assert ("tools.memory_tool", "memory_tool") in wrapped_targets
     assert not any(
         module_name == "tools.session_search_tool"
@@ -186,6 +190,10 @@ def test_uninstrumentation_skips_missing_hermes_targets(
     instrumentation_module.HermesAgentInstrumentor()._uninstrument()
 
     assert (ai_agent, "run_conversation") in unwrapped_targets
+    assert (
+        ai_agent,
+        "_create_request_openai_client",
+    ) in unwrapped_targets
     assert (modules["tools.memory_tool"], "memory_tool") in unwrapped_targets
     assert not any(
         parent is modules["tools.delegate_tool"]
@@ -387,6 +395,423 @@ def _runtime(instrumentation_module, tracer_provider, meter_provider):
             "delegate_task",
         ),
     )
+
+
+class _FakeProviderResource:
+    def __init__(self, responses):
+        self._responses = iter(responses)
+
+    def create(self, **_kwargs):
+        return next(self._responses)
+
+
+class _ReadOnlyProviderResource:
+    __slots__ = ("_response",)
+
+    def __init__(self, response):
+        self._response = response
+
+    def create(self, **_kwargs):
+        return self._response
+
+
+def _provider_client(responses):
+    resource = _FakeProviderResource(responses)
+    return SimpleNamespace(
+        chat=SimpleNamespace(completions=resource),
+        responses=None,
+        completions=None,
+    )
+
+
+def _stream_chunk(response_id=None, *, request_id=None):
+    return SimpleNamespace(id=response_id, request_id=request_id)
+
+
+def _run_streaming_capture(
+    runtime,
+    agent,
+    provider_responses,
+    *,
+    framework_response_id="stream-framework-id",
+):
+    wrappers_module = importlib.import_module(
+        "opentelemetry.instrumentation.hermes_agent.wrappers"
+    )
+    provider_client_wrapper = wrappers_module.ProviderClientWrapper()
+    client = _provider_client(provider_responses)
+
+    def streaming_call(_api_kwargs, *, on_first_delta):
+        request_client = provider_client_wrapper(
+            lambda: client,
+            agent,
+            (),
+            {},
+        )
+        first_delta = True
+        for _chunk in request_client.chat.completions.create(stream=True):
+            if first_delta:
+                first_delta = False
+                on_first_delta()
+        return _response(
+            content="完成",
+            response_id=framework_response_id,
+        )
+
+    runtime.streaming_llm_wrapper(
+        streaming_call,
+        agent,
+        (
+            {
+                "model": agent.model,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        ),
+        {},
+    )
+
+
+def test_streaming_provider_response_id_overrides_hermes_framework_id(
+    instrumentation_module,
+    tracer_provider,
+    meter_provider,
+    span_exporter,
+):
+    runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
+    agent = _FakeAgent(session_id="session-provider-id")
+
+    _run_streaming_capture(
+        runtime,
+        agent,
+        [
+            iter(
+                [
+                    _stream_chunk("chatcmpl-provider-123"),
+                    _stream_chunk("chatcmpl-provider-123"),
+                ]
+            )
+        ],
+    )
+
+    llm_span = _spans_by_kind(span_exporter, "LLM")[0]
+    assert llm_span.attributes["gen_ai.response.id"] == "chatcmpl-provider-123"
+
+
+def test_streaming_request_id_from_usage_trailer_is_preserved(
+    instrumentation_module,
+    tracer_provider,
+    meter_provider,
+    span_exporter,
+):
+    runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
+    agent = _FakeAgent(session_id="session-request-id")
+
+    _run_streaming_capture(
+        runtime,
+        agent,
+        [
+            iter(
+                [
+                    _stream_chunk(),
+                    _stream_chunk(request_id="dashscope-request-456"),
+                ]
+            )
+        ],
+    )
+
+    llm_span = _spans_by_kind(span_exporter, "LLM")[0]
+    assert llm_span.attributes["gen_ai.response.id"] == "dashscope-request-456"
+
+
+def test_streaming_retry_uses_successful_provider_attempt_id(
+    instrumentation_module,
+    tracer_provider,
+    meter_provider,
+    span_exporter,
+):
+    runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
+    agent = _FakeAgent(session_id="session-provider-retry")
+    wrappers_module = importlib.import_module(
+        "opentelemetry.instrumentation.hermes_agent.wrappers"
+    )
+    provider_client_wrapper = wrappers_module.ProviderClientWrapper()
+    client = _provider_client(
+        [
+            iter([_stream_chunk("chatcmpl-failed-attempt")]),
+            iter([_stream_chunk("chatcmpl-successful-attempt")]),
+        ]
+    )
+
+    def streaming_call(_api_kwargs, *, on_first_delta):
+        request_client = provider_client_wrapper(
+            lambda: client,
+            agent,
+            (),
+            {},
+        )
+        for _chunk in request_client.chat.completions.create(stream=True):
+            on_first_delta()
+        for _chunk in request_client.chat.completions.create(stream=True):
+            on_first_delta()
+        return _response(
+            content="恢复成功",
+            response_id="stream-retry-framework-id",
+        )
+
+    runtime.streaming_llm_wrapper(
+        streaming_call,
+        agent,
+        ({"model": agent.model, "messages": []},),
+        {},
+    )
+
+    llm_span = _spans_by_kind(span_exporter, "LLM")[0]
+    assert (
+        llm_span.attributes["gen_ai.response.id"]
+        == "chatcmpl-successful-attempt"
+    )
+
+
+def test_streaming_retry_does_not_reuse_failed_provider_attempt_id(
+    instrumentation_module,
+    tracer_provider,
+    meter_provider,
+    span_exporter,
+):
+    runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
+    agent = _FakeAgent(session_id="session-provider-retry-fallback")
+    wrappers_module = importlib.import_module(
+        "opentelemetry.instrumentation.hermes_agent.wrappers"
+    )
+    provider_client_wrapper = wrappers_module.ProviderClientWrapper()
+    client = _provider_client(
+        [
+            iter([_stream_chunk("chatcmpl-failed-attempt")]),
+            iter([_stream_chunk()]),
+        ]
+    )
+
+    def streaming_call(_api_kwargs, *, on_first_delta):
+        request_client = provider_client_wrapper(
+            lambda: client,
+            agent,
+            (),
+            {},
+        )
+        for _chunk in request_client.chat.completions.create(stream=True):
+            on_first_delta()
+        for _chunk in request_client.chat.completions.create(stream=True):
+            on_first_delta()
+        return _response(
+            content="恢复成功",
+            response_id="stream-retry-framework-fallback",
+        )
+
+    runtime.streaming_llm_wrapper(
+        streaming_call,
+        agent,
+        ({"model": agent.model, "messages": []},),
+        {},
+    )
+
+    llm_span = _spans_by_kind(span_exporter, "LLM")[0]
+    assert (
+        llm_span.attributes["gen_ai.response.id"]
+        == "stream-retry-framework-fallback"
+    )
+
+
+def test_streaming_without_provider_id_falls_back_to_hermes_response_id(
+    instrumentation_module,
+    tracer_provider,
+    meter_provider,
+    span_exporter,
+):
+    runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
+    agent = _FakeAgent(session_id="session-provider-fallback")
+
+    _run_streaming_capture(
+        runtime,
+        agent,
+        [iter([_stream_chunk()])],
+        framework_response_id="stream-hermes-fallback",
+    )
+
+    llm_span = _spans_by_kind(span_exporter, "LLM")[0]
+    assert (
+        llm_span.attributes["gen_ai.response.id"] == "stream-hermes-fallback"
+    )
+
+
+def test_read_only_provider_resource_falls_back_without_breaking_call(
+    instrumentation_module,
+    tracer_provider,
+    meter_provider,
+    span_exporter,
+):
+    runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
+    agent = _FakeAgent(session_id="session-provider-read-only")
+    wrappers_module = importlib.import_module(
+        "opentelemetry.instrumentation.hermes_agent.wrappers"
+    )
+    provider_client_wrapper = wrappers_module.ProviderClientWrapper()
+    resource = _ReadOnlyProviderResource(
+        iter([_stream_chunk("chatcmpl-not-captured")])
+    )
+    client = SimpleNamespace(
+        chat=SimpleNamespace(completions=resource),
+        responses=None,
+        completions=None,
+    )
+
+    def streaming_call(_api_kwargs, *, on_first_delta):
+        request_client = provider_client_wrapper(
+            lambda: client,
+            agent,
+            (),
+            {},
+        )
+        for _chunk in request_client.chat.completions.create(stream=True):
+            on_first_delta()
+        return _response(
+            content="完成",
+            response_id="stream-read-only-fallback",
+        )
+
+    runtime.streaming_llm_wrapper(
+        streaming_call,
+        agent,
+        ({"model": agent.model, "messages": []},),
+        {},
+    )
+
+    llm_span = _spans_by_kind(span_exporter, "LLM")[0]
+    assert (
+        llm_span.attributes["gen_ai.response.id"]
+        == "stream-read-only-fallback"
+    )
+
+
+def test_provider_attempt_from_previous_call_does_not_leak(
+    instrumentation_module,
+    tracer_provider,
+    meter_provider,
+    span_exporter,
+):
+    runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
+    agent = _FakeAgent(session_id="session-provider-stale-attempt")
+    wrappers_module = importlib.import_module(
+        "opentelemetry.instrumentation.hermes_agent.wrappers"
+    )
+    provider_client_wrapper = wrappers_module.ProviderClientWrapper()
+    client = _provider_client(
+        [iter([_stream_chunk("chatcmpl-previous-call")])]
+    )
+    request_client = provider_client_wrapper(lambda: client, agent, (), {})
+    list(request_client.chat.completions.create(stream=True))
+
+    runtime.llm_wrapper(
+        lambda _api_kwargs: _response(
+            content="新调用",
+            response_id="framework-current-call",
+        ),
+        agent,
+        ({"model": agent.model, "messages": []},),
+        {},
+    )
+
+    llm_span = _spans_by_kind(span_exporter, "LLM")[0]
+    assert (
+        llm_span.attributes["gen_ai.response.id"] == "framework-current-call"
+    )
+
+
+def test_native_request_id_precedes_framework_response_id(
+    instrumentation_module,
+    tracer_provider,
+    meter_provider,
+    span_exporter,
+):
+    runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
+    agent = _FakeAgent(session_id="session-native-request-id")
+    response = _response(content="完成", response_id="framework-response-id")
+    response.request_id = "dashscope-native-request-id"
+
+    runtime.llm_wrapper(
+        lambda api_kwargs: response,
+        agent,
+        ({"model": agent.model, "messages": []},),
+        {},
+    )
+
+    llm_span = _spans_by_kind(span_exporter, "LLM")[0]
+    assert (
+        llm_span.attributes["gen_ai.response.id"]
+        == "dashscope-native-request-id"
+    )
+
+
+def test_streaming_provider_response_ids_are_isolated_across_threads(
+    instrumentation_module,
+    tracer_provider,
+    meter_provider,
+    span_exporter,
+):
+    runtime = _runtime(instrumentation_module, tracer_provider, meter_provider)
+    shared_agent = _FakeAgent(session_id="session-provider-concurrent")
+    barrier = threading.Barrier(2)
+    errors = []
+
+    def run_stream(thread_id):
+        try:
+            wrappers_module = importlib.import_module(
+                "opentelemetry.instrumentation.hermes_agent.wrappers"
+            )
+            provider_client_wrapper = wrappers_module.ProviderClientWrapper()
+            client = _provider_client(
+                [iter([_stream_chunk(f"chatcmpl-thread-{thread_id}")])]
+            )
+
+            def streaming_call(_api_kwargs, *, on_first_delta):
+                request_client = provider_client_wrapper(
+                    lambda: client,
+                    shared_agent,
+                    (),
+                    {},
+                )
+                stream = request_client.chat.completions.create(stream=True)
+                next(stream)
+                barrier.wait(timeout=5)
+                on_first_delta()
+                return _response(
+                    content=f"完成-{thread_id}",
+                    response_id=f"stream-framework-{thread_id}",
+                )
+
+            runtime.streaming_llm_wrapper(
+                streaming_call,
+                shared_agent,
+                ({"model": shared_agent.model, "messages": []},),
+                {},
+            )
+        except BaseException as exc:  # pragma: no cover - defensive
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=run_stream, args=(thread_id,))
+        for thread_id in (1, 2)
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert errors == []
+    assert all(not thread.is_alive() for thread in threads)
+    assert {
+        span.attributes["gen_ai.response.id"]
+        for span in _spans_by_kind(span_exporter, "LLM")
+    } == {"chatcmpl-thread-1", "chatcmpl-thread-2"}
 
 
 def test_agent_layer_reuses_existing_entry_instead_of_creating_a_new_one(

--- a/util/opentelemetry-util-genai/CHANGELOG-loongsuite.md
+++ b/util/opentelemetry-util-genai/CHANGELOG-loongsuite.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `hook_advice` and `async_hook_advice` fail-open decorators for
   instrumentation-only logic, with explicit rejection of deferred generator
   lifecycles.
+- Add shared response ID extraction and provider-first fallback helpers for
+  GenAI instrumentations that receive both provider and framework responses.
 
 ## Version 0.7.0 (2026-07-03)
 

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/response_id.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/response_id.py
@@ -1,0 +1,79 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for resolving provider and framework response identifiers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+def _normalize_response_id(value: Any) -> str | None:
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def extract_response_id(
+    response: Any,
+    *,
+    fields: Sequence[str] = ("id",),
+) -> str | None:
+    """Extract the first non-empty identifier from ``response``.
+
+    ``response`` may be an identifier itself, a mapping, or an SDK response
+    object. Field order is deliberately caller-controlled because providers
+    use different names for the same operation identifier. Transport-only
+    fields such as OpenAI's ``_request_id`` are not considered implicitly.
+    """
+
+    direct_identifier = _normalize_response_id(response)
+    if direct_identifier is not None:
+        return direct_identifier
+
+    for field in fields:
+        try:
+            candidate = (
+                response.get(field)
+                if isinstance(response, Mapping)
+                else getattr(response, field, None)
+            )
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Provider SDK properties may raise arbitrary lazy-load errors;
+            # response-ID telemetry must never break the model call.
+            continue
+        identifier = _normalize_response_id(candidate)
+        if identifier is not None:
+            return identifier
+    return None
+
+
+def resolve_response_id(
+    provider_response: Any = None,
+    framework_response: Any = None,
+    *,
+    provider_fields: Sequence[str] = ("id",),
+    framework_fields: Sequence[str] = ("id",),
+) -> str | None:
+    """Prefer a provider identifier and fall back to the framework response."""
+
+    return extract_response_id(
+        provider_response,
+        fields=provider_fields,
+    ) or extract_response_id(
+        framework_response,
+        fields=framework_fields,
+    )

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/response_id.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/response_id.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any
+from typing import Any, cast
 
 
 def _normalize_response_id(value: Any) -> str | None:
@@ -46,11 +46,11 @@ def extract_response_id(
 
     for field in fields:
         try:
-            candidate = (
-                response.get(field)
-                if isinstance(response, Mapping)
-                else getattr(response, field, None)
-            )
+            if isinstance(response, Mapping):
+                mapping_response = cast(Mapping[str, Any], response)
+                candidate = mapping_response.get(field)
+            else:
+                candidate = getattr(response, field, None)
         except Exception:  # pylint: disable=broad-exception-caught
             # Provider SDK properties may raise arbitrary lazy-load errors;
             # response-ID telemetry must never break the model call.

--- a/util/opentelemetry-util-genai/tests/test_response_id.py
+++ b/util/opentelemetry-util-genai/tests/test_response_id.py
@@ -1,0 +1,90 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+
+from opentelemetry.util.genai.response_id import (
+    extract_response_id,
+    resolve_response_id,
+)
+
+
+@pytest.mark.parametrize(
+    ("response", "fields", "expected"),
+    [
+        ("  chatcmpl-123  ", ("id",), "chatcmpl-123"),
+        (123, ("id",), "123"),
+        ({"request_id": "dashscope-123"}, ("request_id",), "dashscope-123"),
+        (SimpleNamespace(id="msg-123"), ("id",), "msg-123"),
+        (
+            {"id": "", "response_id": "resp-123"},
+            ("id", "response_id"),
+            "resp-123",
+        ),
+        (SimpleNamespace(id=None), ("id",), None),
+        (True, ("id",), None),
+    ],
+)
+def test_extract_response_id(response, fields, expected):
+    assert extract_response_id(response, fields=fields) == expected
+
+
+def test_extract_response_id_uses_caller_field_order():
+    response = {"id": "completion-123", "request_id": "request-123"}
+
+    assert (
+        extract_response_id(response, fields=("request_id", "id"))
+        == "request-123"
+    )
+    assert (
+        extract_response_id(response, fields=("id", "request_id"))
+        == "completion-123"
+    )
+
+
+def test_extract_response_id_does_not_use_transport_id_implicitly():
+    response = SimpleNamespace(_request_id="transport-request-123")
+
+    assert extract_response_id(response) is None
+
+
+def test_resolve_response_id_prefers_provider_and_falls_back_to_framework():
+    framework_response = SimpleNamespace(id="stream-framework-123")
+
+    assert (
+        resolve_response_id("chatcmpl-provider-123", framework_response)
+        == "chatcmpl-provider-123"
+    )
+    assert (
+        resolve_response_id(None, framework_response) == "stream-framework-123"
+    )
+
+
+def test_extract_response_id_ignores_raising_sdk_property():
+    class RaisingResponse:
+        @property
+        def request_id(self):
+            raise RuntimeError("not loaded")
+
+        id = "chatcmpl-after-error"
+
+    assert (
+        extract_response_id(
+            RaisingResponse(),
+            fields=("request_id", "id"),
+        )
+        == "chatcmpl-after-error"
+    )


### PR DESCRIPTION
# Description

This PR makes the Hermes instrumentation prefer the model provider's operation/request identifier for `gen_ai.response.id` instead of the synthetic response identifier produced by Hermes.

It adds a shared `util-genai` helper for provider-first response-ID extraction with framework fallback, then uses that helper in Hermes as the first consumer. Hermes observes request-local OpenAI-compatible `chat.completions.create` responses and streaming chunks, isolates retry attempts across worker threads, propagates the selected identifier to LLM and aggregate AGENT spans, and falls back to the Hermes response identifier when the provider does not expose one.

For providers such as DashScope, `request_id` intentionally has higher priority than the OpenAI-compatible completion `id`. A later streaming usage trailer carrying `request_id` can therefore replace an earlier chunk `id`. Transport-only metadata such as `_request_id` and HTTP headers is not read implicitly.

The Hermes package is also aligned with the OpenTelemetry release set used by LoongSuite 0.7.0: compatible-release floors of API/SDK 1.39.1 and instrumentation/semantic-conventions 0.60b1, with the exact set pinned in tests.

Fixes # (N/A)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `tox -e precommit`
- [x] `pyright util/opentelemetry-util-genai/src/opentelemetry/util/genai/response_id.py`
- [x] `pytest -q util/opentelemetry-util-genai/tests/test_response_id.py instrumentation-loongsuite/loongsuite-instrumentation-hermes-agent/tests/test_telemetry_spec.py`
- [x] Built both changed wheels and installed them together in a fresh Python 3.11 environment using standard PyPI dependency resolution.

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Documentation has been updated

## Validation Evidence

### Spec and Scope

- Approved behavior: prefer a provider-returned `request_id`, `id`, or `response_id`; fall back to the Hermes response ID only when no provider value is available.
- Shared abstraction: normalize, extract, and resolve response IDs while keeping field priority caller-configured.
- First consumer: Hermes OpenAI-compatible chat completions, including synchronous, streaming, retry, tool-loop, and worker-thread paths.
- Non-goals: bulk migration of other instrumentations, Responses API, Anthropic Messages API, and transport-header extraction.

### Local Checks

| Check | Result | Evidence |
| --- | --- | --- |
| Static readiness | pass | LoongSuite PR readiness checker reported no blocking findings. |
| Precommit | pass | Ruff, Ruff format, uv-lock, and rstcheck passed. |
| Pyright | pass | The changed `response_id.py` reports 0 errors, 0 warnings, and 0 information messages. |
| Focused tests | pass | 57 response-ID and Hermes telemetry tests passed. |
| Dependency resolution | pass | Fresh wheel installation resolved API/SDK 1.39.1 and instrumentation/threading/semantic-conventions 0.60b1; package compatibility check passed. |
| Independent Qoder review | pass | Two review rounds completed with no blocking defects; the streaming trailer priority edge identified in review was fixed and covered by a focused test. |
| Privacy scan | pass | No credentials, private trace IDs, local user paths, or generated telemetry artifacts are included in the diff. |

### Real E2E Matrix

| Scenario | Status | Evidence |
| --- | --- | --- |
| non-streaming | pass | An isolated Hermes 0.19.0 run through DashScope exported the provider identifier on both LLM and AGENT spans. |
| streaming | pass | Streaming exported a provider identifier with TTFT and no Hermes `stream-*` fallback. |
| concurrency | pass | Two simultaneous calls produced distinct provider identifiers without cross-call contamination. |
| agent/tool/ReAct | pass | A real tool loop produced two LLM calls around one TOOL call; AGENT retained the final provider identifier. |
| tool-heavy | N/A | Response-ID capture is provider-call scoped; the two-LLM tool loop exercises aggregation, while multiple tool definitions do not change the capture path. |
| error path | pass | A bounded connection-error run emitted ERROR LLM/STEP spans without inventing a provider response ID. |

### Telemetry and Weaver

| Check | Status | Evidence |
| --- | --- | --- |
| Span tree / span kinds | pass | The isolated run captured 45 spans locally and the backend readback returned the same 45 spans across ENTRY, AGENT, STEP, LLM, and TOOL kinds. |
| Content capture modes | pass | Response-ID selection remains independent of message-content capture; no-content behavior remains covered by focused tests. |
| Concurrency isolation | pass | Deterministic threaded tests and the real two-call run both kept response IDs invocation-local. |
| Weaver live-check | pass | Eight real-provider LLM samples were filtered to remove content and trace identifiers, then passed the LoongSuite GenAI advice profile with no violations. |

### CI

- The previous remote head passed all checks except `typecheck`, which reported the two Pyright Unknown-type errors fixed by this update.
- The PR remains a draft while the fresh full-matrix checks run for this commit.
- The full local tox typecheck environment was not used as final evidence because it bootstraps large unrelated SDK packages; the changed file passed Pyright directly, and GitHub CI remains the authoritative full typecheck gate.
