### PR TITLE
feat(examples): use Chinese ecommerce agent names

### DIFF
--- a/examples/ecommerce-customer-service/README.md
+++ b/examples/ecommerce-customer-service/README.md
@@ -18,10 +18,12 @@ Chinese customer question
 ```
 
 The router, specialist prompts, synthetic data, tool results, CLI, and customer
-responses use Simplified Chinese. Stable Python identifiers and graph node names
-remain in English. The two specialist branches use separate prompts and tools.
-All products, orders, policies, and tool results are fictional fixtures in
-`tools.py`.
+responses use Simplified Chinese. The specialist Agent display names are
+`售前服务` and `售后服务`, so their observable spans are named
+`invoke_agent 售前服务` and `invoke_agent 售后服务`. Stable Python identifiers,
+graph node names, tool names, and route values remain in English. The two
+specialist branches use separate prompts and tools. All products, orders,
+policies, and tool results are fictional fixtures in `tools.py`.
 
 ## Install
 
@@ -82,6 +84,8 @@ For a detailed scenario walkthrough and a ready-to-use training script, see
 With LangChain and LangGraph instrumentation enabled, a specialist request is
 expected to include the router LLM, the selected Agent, ReAct Step, Tool/LLM
 children, and the final reviewer LLM. Only the chosen specialist branch runs.
+The outer graph nodes remain `presales_agent` and `aftersales_agent`, while the
+inner Agent spans use the Chinese display names above.
 
 ## Test
 

--- a/examples/ecommerce-customer-service/README.zh-CN.md
+++ b/examples/ecommerce-customer-service/README.zh-CN.md
@@ -20,8 +20,10 @@ LangGraph Agent API。
 工具结果全部是虚构数据。
 
 运行时的意图识别提示词、专业 Agent 提示词、工具说明、虚构数据、异常兜底及
-最终回答均使用简体中文。为了保持代码规范和 Trace 名称稳定，Python 标识符、
-节点名和内部路由值仍使用英文。
+最终回答均使用简体中文。专业 Agent 的显示名称为“售前服务”和“售后服务”，
+因此可观测链路中会显示 `invoke_agent 售前服务` 或
+`invoke_agent 售后服务`。为了保持代码接口稳定，Python 标识符、LangGraph
+节点名、工具名和内部路由值仍使用英文。
 
 ## 安装
 
@@ -77,7 +79,9 @@ loongsuite-instrument python app.py \
 
 启用 LangChain 和 LangGraph 埋点后，一次专业客服请求应包含路由 LLM、
 被选中的 Agent、ReAct Step、Tool/LLM 子节点以及最终审查 LLM；未选中的
-专业 Agent 不会执行。
+专业 Agent 不会执行。外层编排节点仍显示为 `presales_agent` 或
+`aftersales_agent`，其内部专业 Agent 分别显示为 `invoke_agent 售前服务` 或
+`invoke_agent 售后服务`。
 
 ## 培训讲解指南
 

--- a/examples/ecommerce-customer-service/tests/test_workflow.py
+++ b/examples/ecommerce-customer-service/tests/test_workflow.py
@@ -24,7 +24,13 @@ from tools import (
     query_after_sales_policy,
     search_product_catalog,
 )
-from workflow import EcommerceSupportWorkflow, IntentDecision, select_route
+from workflow import (
+    AFTERSALES_AGENT_NAME,
+    PRESALES_AGENT_NAME,
+    EcommerceSupportWorkflow,
+    IntentDecision,
+    select_route,
+)
 
 
 class KeywordClassifier:
@@ -224,9 +230,9 @@ def test_presales_and_aftersales_use_different_agents() -> None:
 
     assert presales["route"] == "presales"
     assert aftersales["route"] == "aftersales"
-    assert calls == ["presales_agent", "aftersales_agent"]
-    assert "presales_agent_tool" in model.review_inputs[0]
-    assert "aftersales_agent_tool" in model.review_inputs[1]
+    assert calls == [PRESALES_AGENT_NAME, AFTERSALES_AGENT_NAME]
+    assert f"{PRESALES_AGENT_NAME}_tool" in model.review_inputs[0]
+    assert f"{AFTERSALES_AGENT_NAME}_tool" in model.review_inputs[1]
 
 
 @pytest.mark.parametrize(
@@ -281,10 +287,10 @@ def test_ambiguous_question_uses_clarification_without_a_specialist() -> None:
 
 def test_specialist_and_reviewer_fail_open() -> None:
     workflow, _, calls = make_workflow(
-        fail_review=True, fail_agent="presales_agent"
+        fail_review=True, fail_agent=PRESALES_AGENT_NAME
     )
     result = workflow.run("云步通勤鞋有货吗？")
-    assert calls == ["presales_agent"]
+    assert calls == [PRESALES_AGENT_NAME]
     assert result["route"] == "presales"
     assert result["final_response"].startswith("售前客服暂时不可用")
 

--- a/examples/ecommerce-customer-service/workflow.py
+++ b/examples/ecommerce-customer-service/workflow.py
@@ -13,6 +13,9 @@ from tools import AFTERSALES_TOOLS, PRESALES_TOOLS
 
 Route = Literal["presales", "aftersales", "clarify"]
 
+PRESALES_AGENT_NAME = "售前服务"
+AFTERSALES_AGENT_NAME = "售后服务"
+
 PRESALES_PROMPT = """你是虚构电商店铺的售前客服。
 只能使用提供的虚构商品目录、商品知识和库存工具。
 回答前至少调用一个工具；工具未提供的信息要明确说明不知道。
@@ -159,13 +162,13 @@ class EcommerceSupportWorkflow:
         )
         self.confidence_threshold = confidence_threshold
         self.presales_agent = agent_factory(
-            name="presales_agent",
+            name=PRESALES_AGENT_NAME,
             model=model,
             tools=PRESALES_TOOLS,
             prompt=PRESALES_PROMPT,
         )
         self.aftersales_agent = agent_factory(
-            name="aftersales_agent",
+            name=AFTERSALES_AGENT_NAME,
             model=model,
             tools=AFTERSALES_TOOLS,
             prompt=AFTERSALES_PROMPT,


### PR DESCRIPTION
# Description

This is a follow-up to #260. It changes the two ecommerce customer-service agent display names from English to Chinese so that traces for Chinese users show:

- `invoke_agent 售前服务`
- `invoke_agent 售后服务`

The LangGraph node names, Python identifiers, route values, and tool names remain in English to keep the implementation stable and easy to maintain.

The English and Chinese READMEs now document the expected trace names.

Fixes # (N/A)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `cd examples/ecommerce-customer-service && uv run --isolated --no-project --with-requirements requirements.txt --with-requirements requirements-dev.txt python -m pytest tests -q` (`10 passed`)
- [x] `tox -e precommit`
- [x] Local telemetry smoke verified both Chinese `invoke_agent` span names and `gen_ai.agent.name` values
- [x] Provider-backed deployment smoke covered presales, aftersales, and clarification requests
- [x] Cloud trace readback verified the specialist, ReAct model/tool, business-tool, and reviewer span chain
- [x] Independent diff review completed with zero actionable findings

## Validation Evidence

| Area | Result | Evidence / reason |
| --- | --- | --- |
| Scope | Pass | Example and its tests/docs only; no instrumentation package changed |
| Focused tests | Pass | 10 tests passed |
| Pre-commit | Pass | All repository hooks passed from a fresh cache |
| Test-first regression | N/A | This is an example display-name configuration change, not an instrumentation bug fix |
| Provider VCR | N/A | No provider client or instrumentation behavior changed |
| Non-streaming workflow | Pass | Presales, aftersales, and clarification paths returned successfully |
| Streaming workflow | N/A | This example intentionally uses the non-streaming `invoke` workflow |
| Concurrent request isolation | Pass | Existing concurrency test passed |
| Agent/tool/ReAct flow | Pass | Both specialist agents invoked their expected tools before review |
| Error/fail-open path | Pass | Existing error-path tests passed |
| Trace tree | Pass | Chinese specialist span names and agent attributes were observed while English graph nodes remained unchanged |
| Content capture | N/A | No content-capture behavior changed |
| Weaver semantic check | N/A | No semantic-convention registry or instrumentation mapping changed; the existing exported contract was checked by cloud trace readback |
| GitHub CI | Pending | CI starts after the PR is published |

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR:
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated

The PR should carry the `Skip Changelog` label because it only adjusts an example's user-facing agent names and documentation.
