### PR TITLE
fix(agentscope): normalize v2 messages, inherit sessions and capture cache usage

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Capture cache-read and cache-creation input tokens in AgentScope v1 and v2,
+  including final streaming and v2 agent usage, without adding cached tokens
+  to input totals.
 - Split AgentScope v2 cumulative assistant history at tool results, preserving
   chronological assistant/tool roles without changing the application context.
 - Respect the model formatter's thinking-input capability in LLM history and

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Split AgentScope v2 cumulative assistant history at tool results, preserving
+  chronological assistant/tool roles without changing the application context.
+- Respect the model formatter's thinking-input capability in LLM history and
+  limit agent output to final visible text, leaving reasoning and tools on child spans.
+- Prefer Entry session/user baggage over AgentScope's internal session identity
+  and propagate the conversation to ReAct, LLM, and tool spans.
+- Fail open when v2 input conversion fails and finalize agent spans even when
+  output conversion raises.
+
 ## Version 0.8.0 (2026-07-31)
 
 ### Fixed

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Preserve QwenPaw Dream owner names across ReMe helper Agent invocations.
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Treat AgentScope v2 cancellation as control flow, with an explicit
+  `agentscope.cancelled` attribute, including interrupted reply events when
+  the framework consumes the exception. Preserve business exceptions and do
+  not invent final LLM usage or finish reasons for interrupted streams.
 - Capture cache-read and cache-creation input tokens in AgentScope v1 and v2,
   including final streaming and v2 agent usage, without adding cached tokens
   to input totals.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_usage.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_usage.py
@@ -1,0 +1,58 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cache usage extraction shared by AgentScope v1 and v2 adapters."""
+
+from typing import Any
+
+from opentelemetry.util.genai import hook_advice
+from opentelemetry.util.genai.extended_types import InvokeAgentInvocation
+from opentelemetry.util.genai.types import LLMInvocation
+
+
+def _safe_get(obj: Any, key: str) -> Any:
+    """Support ChatUsage dicts whose missing attributes raise KeyError."""
+    if isinstance(obj, dict):
+        return obj.get(key)
+    try:
+        return getattr(obj, key, None)
+    except (KeyError, AttributeError):
+        return None
+
+
+@hook_advice("agentscope", "extract_cache_tokens")
+def _extract_cache_tokens(
+    usage: Any, invocation: LLMInvocation | InvokeAgentInvocation
+) -> None:
+    """Read AgentScope, Anthropic and OpenAI/DashScope cache usage fields.
+
+    Explicit top-level values, including zero, take precedence. Fall back
+    independently for each counter; absent usage must not imply a cache miss.
+    """
+    cache_creation = _safe_get(usage, "cache_creation_input_tokens")
+    cache_read = _safe_get(usage, "cache_read_input_tokens")
+    if cache_read is None:
+        cache_read = _safe_get(usage, "cache_input_tokens")
+
+    if cache_creation is None or cache_read is None:
+        details = _safe_get(usage, "prompt_tokens_details")
+        if cache_creation is None:
+            cache_creation = _safe_get(details, "cache_creation_input_tokens")
+        if cache_read is None:
+            cache_read = _safe_get(details, "cached_tokens")
+
+    if cache_creation is not None:
+        invocation.usage_cache_creation_input_tokens = cache_creation
+    if cache_read is not None:
+        invocation.usage_cache_read_input_tokens = cache_read

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
@@ -36,6 +36,7 @@ from agentscope.middleware import MiddlewareBase
 from agentscope.model import ChatModelBase, ChatResponse
 from agentscope.tool import ToolResponse
 
+from opentelemetry import baggage
 from opentelemetry import context as otel_context
 from opentelemetry.context import Context, get_current
 from opentelemetry.util.genai import hook_advice
@@ -208,6 +209,10 @@ def _start_agent(
     try:
         handler.start_invoke_agent(invocation)
         agent_context = get_current()
+        if invocation.conversation_id:
+            agent_context = baggage.set_baggage(
+                "gen_ai.session.id", invocation.conversation_id, agent_context
+            )
     except Exception:
         _abandon_invocation(invocation)
         raise
@@ -251,17 +256,16 @@ def _finish_agent(
     state.finalized = True
 
     invocation = state.invocation
-    if state.last_msg is not None:
-        invocation.output_messages = [_message_to_output(state.last_msg)]
-        if state.last_msg.usage is not None:
-            invocation.input_tokens = state.last_msg.usage.input_tokens
-            invocation.output_tokens = state.last_msg.usage.output_tokens
-
     token = None
     span = invocation.span
     try:
         token = otel_context.attach(state.context)
         invocation.context_token = token
+        if state.last_msg is not None:
+            invocation.output_messages = [_message_to_output(state.last_msg)]
+            if state.last_msg.usage is not None:
+                invocation.input_tokens = state.last_msg.usage.input_tokens
+                invocation.output_tokens = state.last_msg.usage.output_tokens
         if error is None or isinstance(error, GeneratorExit):
             state.handler.stop_invoke_agent(invocation)
         else:
@@ -293,6 +297,7 @@ def _start_react(
         )
         + 1
     )
+    _apply_identity(react_invocation, context=context)
 
     try:
         handler.start_react_step(react_invocation, context=context)
@@ -347,6 +352,7 @@ def _create_tool_invocation(
         tool_call_arguments=tool_call_arguments,
         provider="agentscope",
     )
+    _apply_identity(tool_invocation)
     _apply_skill_metadata(
         tool_invocation,
         agent,
@@ -633,6 +639,10 @@ class AgentScopeV2Middleware(MiddlewareBase):
             return
 
         invocation = _create_agent_invocation(agent, input_kwargs)
+        if invocation is None:
+            async for item in next_handler(**input_kwargs):
+                yield item
+            return
         state = _start_agent(handler, invocation)
         try:
             business_stream = next_handler(**input_kwargs)
@@ -778,6 +788,8 @@ class AgentScopeV2Middleware(MiddlewareBase):
             return await next_handler(**input_kwargs)
 
         invocation = _create_llm_invocation(model, input_kwargs)
+        if invocation is None:
+            return await next_handler(**input_kwargs)
         state = _start_llm(handler, invocation, get_current())
         try:
             result = await next_handler(**input_kwargs)
@@ -909,6 +921,25 @@ class AgentScopeV2Middleware(MiddlewareBase):
                 _finish_acting(state)
 
 
+def _apply_identity(
+    invocation: Any, context: Context | None = None
+) -> str | None:
+    """Prefer the Entry's business identity over framework-local state IDs.
+
+    Use ordinary W3C baggage, as the v1 adapter does. Robin's additional
+    traffic-coloring prefix is intentionally not part of the OSS contract.
+    """
+    for key in ("gen_ai.session.id", "gen_ai.user.id"):
+        value = baggage.get_baggage(key, context=context)
+        if isinstance(value, str) and value.strip():
+            invocation.attributes[key] = value
+    session_id = invocation.attributes.get("gen_ai.session.id")
+    if session_id:
+        invocation.attributes["gen_ai.conversation.id"] = session_id
+    return session_id
+
+
+@hook_advice("agentscope", "create_agent_invocation")
 def _create_agent_invocation(
     agent: Agent,
     input_kwargs: dict[str, Any],
@@ -917,7 +948,7 @@ def _create_agent_invocation(
     request_model = getattr(model, "model", None)
     provider = _get_provider_name(model)
     inputs = input_kwargs.get("inputs")
-    return InvokeAgentInvocation(
+    invocation = InvokeAgentInvocation(
         provider=provider,
         agent_name=getattr(agent, "name", "unknown_agent"),
         agent_id=getattr(getattr(agent, "state", None), "session_id", None),
@@ -930,8 +961,13 @@ def _create_agent_invocation(
             Text(content=getattr(agent, "_system_prompt", ""))
         ],
     )
+    session_id = _apply_identity(invocation)
+    if session_id:
+        invocation.conversation_id = session_id
+    return invocation
 
 
+@hook_advice("agentscope", "create_llm_invocation")
 def _create_llm_invocation(
     model: ChatModelBase,
     input_kwargs: dict[str, Any],
@@ -939,9 +975,17 @@ def _create_llm_invocation(
     invocation = LLMInvocation(
         request_model=getattr(model, "model", None),
         provider=_get_provider_name(model),
-        input_messages=_messages_to_inputs(input_kwargs.get("messages")),
+        input_messages=_messages_to_inputs(
+            input_kwargs.get("messages"),
+            include_reasoning=getattr(
+                getattr(model, "formatter", None),
+                "supports_thinking_input",
+                True,
+            ),
+        ),
         tool_definitions=_tool_definitions(input_kwargs.get("tools")),
     )
+    _apply_identity(invocation)
     parameters = getattr(model, "parameters", None)
     for source in (parameters, input_kwargs):
         _set_if_present(invocation, "temperature", source)
@@ -964,26 +1008,49 @@ def _finish_llm_invocation(
         invocation.output_tokens = getattr(usage, "output_tokens", None)
 
 
-def _messages_to_inputs(value: Any) -> list[InputMessage]:
+def _messages_to_inputs(
+    value: Any, *, include_reasoning: bool = True
+) -> list[InputMessage]:
     if value is None:
         return []
     if isinstance(value, Msg):
-        return [_message_to_input(value)]
-    if isinstance(value, list):
-        return [
-            _message_to_input(item) for item in value if isinstance(item, Msg)
-        ]
-    return []
-
-
-def _message_to_input(msg: Msg) -> InputMessage:
-    return InputMessage(role=msg.role, parts=_blocks_to_parts(msg.content))
+        value = [value]
+    if not isinstance(value, (list, tuple)):
+        return []
+    messages = []
+    for msg in value:
+        if not isinstance(msg, Msg):
+            continue
+        pending = []
+        # AgentScope v2 keeps multiple ReAct rounds in one assistant Msg.
+        # Emit tool results as separate messages, preserving call/result order
+        # without modifying the framework's persisted conversation.
+        for part in _blocks_to_parts(msg.content):
+            if isinstance(part, ToolCallResponse):
+                if pending:
+                    messages.append(InputMessage(role=msg.role, parts=pending))
+                    pending = []
+                messages.append(InputMessage(role="tool", parts=[part]))
+            elif include_reasoning or not isinstance(part, Reasoning):
+                pending.append(part)
+        if pending:
+            messages.append(InputMessage(role=msg.role, parts=pending))
+    return messages
 
 
 def _message_to_output(msg: Msg) -> OutputMessage:
+    # The reply Msg is cumulative, not just the final response. Keep only
+    # visible text after the last tool interaction at the AGENT boundary;
+    # intermediate reasoning and tools remain on their child spans.
+    parts = []
+    for part in _blocks_to_parts(msg.content):
+        if isinstance(part, (ToolCall, ToolCallResponse)):
+            parts = []
+        elif isinstance(part, Text):
+            parts.append(part)
     return OutputMessage(
         role=msg.role,
-        parts=_blocks_to_parts(msg.content),
+        parts=parts,
         finish_reason="stop",
     )
 

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
@@ -983,7 +983,8 @@ def _create_agent_invocation(
     inputs = input_kwargs.get("inputs")
     invocation = InvokeAgentInvocation(
         provider=provider,
-        agent_name=getattr(agent, "name", "unknown_agent"),
+        agent_name=otel_context.get_value("qwenpaw.dream.agent.name")
+        or getattr(agent, "name", "unknown_agent"),
         agent_id=getattr(getattr(agent, "state", None), "session_id", None),
         conversation_id=getattr(
             getattr(agent, "state", None), "session_id", None

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
@@ -60,6 +60,7 @@ from opentelemetry.util.genai.types import (
 )
 
 from ._skill import _enrich_skill_metadata
+from ._usage import _extract_cache_tokens
 
 logger = logging.getLogger(__name__)
 
@@ -266,6 +267,7 @@ def _finish_agent(
             if state.last_msg.usage is not None:
                 invocation.input_tokens = state.last_msg.usage.input_tokens
                 invocation.output_tokens = state.last_msg.usage.output_tokens
+                _extract_cache_tokens(state.last_msg.usage, invocation)
         if error is None or isinstance(error, GeneratorExit):
             state.handler.stop_invoke_agent(invocation)
         else:
@@ -1006,6 +1008,7 @@ def _finish_llm_invocation(
     if usage is not None:
         invocation.input_tokens = getattr(usage, "input_tokens", None)
         invocation.output_tokens = getattr(usage, "output_tokens", None)
+        _extract_cache_tokens(usage, invocation)
 
 
 def _messages_to_inputs(

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_v2_middleware.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 import logging
@@ -70,6 +71,15 @@ _FIRST_TOKEN_EVENT_TYPES = {
     "thinking_block_delta",
     "tool_call_delta",
 }
+
+
+@hook_advice("agentscope", "record_cancellation")
+def _record_cancellation(invocation: Any, error: BaseException | None) -> None:
+    if (
+        isinstance(error, asyncio.CancelledError)
+        and invocation.span is not None
+    ):
+        invocation.span.set_attribute("agentscope.cancelled", True)
 
 
 @dataclass
@@ -179,7 +189,10 @@ def _finish_llm(
     try:
         token = otel_context.attach(state.context)
         invocation.context_token = token
-        if error is None or isinstance(error, GeneratorExit):
+        _record_cancellation(invocation, error)
+        if error is None or isinstance(
+            error, (GeneratorExit, asyncio.CancelledError)
+        ):
             if error is None or getattr(state.last_chunk, "is_last", False):
                 _finish_llm_invocation(invocation, state.last_chunk)
             state.handler.stop_llm(invocation)
@@ -240,6 +253,13 @@ def _detach_stream_context(token: object | None) -> None:
 
 @hook_advice("agentscope", "record_agent_chunk")
 def _record_agent_chunk(state: _AgentState, item: Any) -> None:
+    # AgentScope may consume CancelledError and emit an interrupted reply
+    # instead. Preserve that signal without changing the framework behavior.
+    reason = getattr(item, "finished_reason", None)
+    if getattr(reason, "value", reason) == "interrupted":
+        if state.invocation.span is not None:
+            state.invocation.span.set_attribute("agentscope.cancelled", True)
+        state.invocation.finish_reasons = ["interrupted"]
     if not state.first_token_seen and _is_first_token_event(item):
         state.invocation.monotonic_first_token_s = timeit.default_timer()
         state.first_token_seen = True
@@ -268,7 +288,10 @@ def _finish_agent(
                 invocation.input_tokens = state.last_msg.usage.input_tokens
                 invocation.output_tokens = state.last_msg.usage.output_tokens
                 _extract_cache_tokens(state.last_msg.usage, invocation)
-        if error is None or isinstance(error, GeneratorExit):
+        _record_cancellation(invocation, error)
+        if error is None or isinstance(
+            error, (GeneratorExit, asyncio.CancelledError)
+        ):
             state.handler.stop_invoke_agent(invocation)
         else:
             state.handler.fail_invoke_agent(
@@ -458,7 +481,9 @@ def _finish_tool(
     state.tool_finalized = True
 
     invocation = state.tool_invocation
-    if error is None or isinstance(error, GeneratorExit):
+    if error is None or isinstance(
+        error, (GeneratorExit, asyncio.CancelledError)
+    ):
         if isinstance(state.last_item, ToolResponse):
             invocation.tool_call_result = _jsonable(
                 _blocks_to_parts(state.last_item.content)
@@ -471,7 +496,10 @@ def _finish_tool(
     try:
         token = otel_context.attach(state.tool_context)
         invocation.context_token = token
-        if error is None or isinstance(error, GeneratorExit):
+        _record_cancellation(invocation, error)
+        if error is None or isinstance(
+            error, (GeneratorExit, asyncio.CancelledError)
+        ):
             state.handler.stop_execute_tool(invocation)
         else:
             state.handler.fail_execute_tool(
@@ -505,7 +533,10 @@ def _finish_react(
     failure = error
     if failure is None:
         failure = state.error
-    if isinstance(failure, GeneratorExit):
+    _record_cancellation(invocation, failure)
+    if isinstance(failure, (GeneratorExit, asyncio.CancelledError)):
+        if isinstance(failure, asyncio.CancelledError):
+            invocation.finish_reason = None
         failure = None
 
     token = None

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_wrapper.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/src/opentelemetry/instrumentation/agentscope/_wrapper.py
@@ -69,6 +69,7 @@ from opentelemetry.util.genai.extended_handler import ExtendedTelemetryHandler
 from opentelemetry.util.genai.extended_types import ReactStepInvocation
 from opentelemetry.util.genai.types import Error, LLMInvocation
 
+from ._usage import _extract_cache_tokens
 from .utils import (
     apply_entry_baggage_identity,
     convert_agent_response_to_output_messages,
@@ -414,6 +415,7 @@ class AgentScopeChatModelWrapper:
                     invocation.output_tokens = getattr(
                         last_chunk.usage, "output_tokens", None
                     )
+                    _extract_cache_tokens(last_chunk.usage, invocation)
 
                 if hasattr(last_chunk, "id"):
                     invocation.response_id = getattr(last_chunk, "id", None)
@@ -493,6 +495,7 @@ class AgentScopeChatModelWrapper:
                         invocation.output_tokens = getattr(
                             result.usage, "output_tokens", None
                         )
+                        _extract_cache_tokens(result.usage, invocation)
 
                     invocation.response_model = invocation.request_model
                     invocation.response_finish_reasons = ["stop"]

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/requirements.oldest.txt
@@ -16,6 +16,8 @@
 # the oldest supported version of external dependencies.
 
 agentscope>=1.0.0,<2.0.0
+# AgentScope 1.x imports tqdm without declaring it as a runtime dependency.
+tqdm
 mcp<2
 pytest
 pytest-asyncio

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_call_chain_reentrancy.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_call_chain_reentrancy.py
@@ -11,7 +11,47 @@ import pytest
 agentscope = pytest.importorskip("agentscope")
 from agentscope.agent import AgentBase  # noqa: E402
 from agentscope.message import Msg  # noqa: E402
-from agentscope.model import ChatModelBase, ChatResponse  # noqa: E402
+from agentscope.model import (  # noqa: E402
+    ChatModelBase,
+    ChatResponse,
+)
+from agentscope.model._model_usage import ChatUsage  # noqa: E402
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_model_cache_usage(
+    instrument_with_content, span_exporter, streaming
+):
+    class CacheModel(ChatModelBase):
+        def __init__(self):
+            super().__init__("cache-model", streaming)
+
+        async def __call__(self, *args, **kwargs):
+            usage = ChatUsage(input_tokens=200, output_tokens=10, time=0.1)
+            usage["cache_input_tokens"] = 100
+            usage["cache_creation_input_tokens"] = 40
+            result = ChatResponse(
+                content=[{"type": "text", "text": "ok"}], usage=usage
+            )
+
+            async def chunks():
+                yield result
+
+            return chunks() if streaming else result
+
+    result = await CacheModel()([])
+    if streaming:
+        result = [chunk async for chunk in result][-1]
+    assert result.content[0]["text"] == "ok"
+    [span] = [
+        s
+        for s in span_exporter.get_finished_spans()
+        if s.name.startswith("chat ")
+    ]
+    assert span.attributes["gen_ai.usage.cache_read.input_tokens"] == 100
+    assert span.attributes["gen_ai.usage.cache_creation.input_tokens"] == 40
+    assert span.attributes["gen_ai.usage.input_tokens"] == 200
 
 
 @pytest.mark.asyncio

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_model.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_model.py
@@ -180,7 +180,7 @@ def _assert_chat_span_attributes(
         )
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr(record_mode="none")
 def test_model_call_basic(instrument_no_content, span_exporter, request):
     """Test basic model call"""
     # Initialize agentscope
@@ -220,6 +220,16 @@ def test_model_call_basic(instrument_no_content, span_exporter, request):
 
     # Verify span attributes
     chat_span = chat_spans[0]
+    # Older ChatUsage versions may omit counters; do not fabricate a miss.
+    if "cache_input_tokens" in response.usage:
+        assert (
+            chat_span.attributes["gen_ai.usage.cache_read.input_tokens"]
+            == response.usage["cache_input_tokens"]
+        )
+    else:
+        assert (
+            "gen_ai.usage.cache_read.input_tokens" not in chat_span.attributes
+        )
     _assert_chat_span_attributes(
         chat_span,
         request_model="qwen-max",

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_utils.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_utils.py
@@ -19,6 +19,7 @@ Tests for utility functions in opentelemetry.instrumentation.agentscope.utils
 
 from types import SimpleNamespace
 
+import pytest
 from agentscope.message import Msg, ToolResultBlock
 from agentscope.tracing._converter import (
     _convert_block_to_part as _convert_block_to_part_framework,
@@ -27,6 +28,10 @@ from agentscope.tracing._converter import (
 from opentelemetry import baggage
 from opentelemetry import context as otel_context
 from opentelemetry.instrumentation.agentscope import utils as utils_module
+from opentelemetry.instrumentation.agentscope._usage import (
+    _extract_cache_tokens,
+    _safe_get,
+)
 from opentelemetry.instrumentation.agentscope.utils import (
     _convert_block_to_part as _convert_block_to_part_local,
 )
@@ -43,7 +48,81 @@ from opentelemetry.util.genai.extended_semconv.gen_ai_extended_attributes import
     GEN_AI_USER_ID,
 )
 from opentelemetry.util.genai.extended_types import ReactStepInvocation
-from opentelemetry.util.genai.types import ToolCallResponse
+from opentelemetry.util.genai.types import LLMInvocation, ToolCallResponse
+
+
+@pytest.mark.parametrize(
+    "usage,read,creation",
+    [
+        (None, None, None),
+        ({"input_tokens": 200}, None, None),
+        (
+            {"cache_input_tokens": 100, "cache_creation_input_tokens": 40},
+            100,
+            40,
+        ),
+        ({"cache_read_input_tokens": 80, "cache_input_tokens": 100}, 80, None),
+        ({"prompt_tokens_details": {"cached_tokens": 70}}, 70, None),
+        (
+            SimpleNamespace(
+                prompt_tokens_details=SimpleNamespace(cached_tokens=60)
+            ),
+            60,
+            None,
+        ),
+        (
+            {
+                "cache_creation_input_tokens": 0,
+                "prompt_tokens_details": {"cached_tokens": 50},
+            },
+            50,
+            0,
+        ),
+        (
+            {
+                "cache_read_input_tokens": 0,
+                "prompt_tokens_details": {
+                    "cached_tokens": 90,
+                    "cache_creation_input_tokens": 30,
+                },
+            },
+            0,
+            30,
+        ),
+    ],
+)
+def test_extract_cache_tokens(usage, read, creation):
+    invocation = LLMInvocation(input_tokens=200, output_tokens=10)
+    _extract_cache_tokens(usage, invocation)
+    assert invocation.usage_cache_read_input_tokens == read
+    assert invocation.usage_cache_creation_input_tokens == creation
+    assert invocation.input_tokens == 200
+    assert invocation.output_tokens == 10
+
+
+def test_cache_usage_missing_dict_attributes():
+    class DictUsage(dict):
+        def __getattr__(self, key):
+            return self[key]
+
+    usage = DictUsage(cache_input_tokens=0)
+    assert _safe_get(usage, "missing") is None
+    invocation = LLMInvocation()
+    _extract_cache_tokens(usage, invocation)
+    assert invocation.usage_cache_read_input_tokens == 0
+    assert invocation.usage_cache_creation_input_tokens is None
+
+
+def test_cache_usage_broken_property_is_fail_open():
+    class BrokenUsage:
+        @property
+        def cache_creation_input_tokens(self):
+            raise RuntimeError("usage accessor failed")
+
+    invocation = LLMInvocation(input_tokens=200)
+    _extract_cache_tokens(BrokenUsage(), invocation)
+    assert invocation.input_tokens == 200
+    assert invocation.usage_cache_read_input_tokens is None
 
 
 class TestUtils:

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_v2_instrumentation.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_v2_instrumentation.py
@@ -36,6 +36,7 @@ from agentscope.credential import DashScopeCredential  # noqa: E402
 from agentscope.message import (  # noqa: E402
     Msg,
     TextBlock,
+    ThinkingBlock,
     ToolCallBlock,
     ToolResultBlock,
     UserMsg,
@@ -43,10 +44,17 @@ from agentscope.message import (  # noqa: E402
 from agentscope.model import ChatResponse, DashScopeChatModel  # noqa: E402
 from agentscope.tool import ToolResponse  # noqa: E402
 
+from opentelemetry import baggage, context  # noqa: E402
 from opentelemetry import trace as trace_api  # noqa: E402
+from opentelemetry.instrumentation.agentscope import (  # noqa: E402
+    _v2_middleware,
+)
 from opentelemetry.instrumentation.agentscope._v2_middleware import (  # noqa: E402
     AgentScopeV2Middleware,
-    _message_to_input,
+    _create_agent_invocation,
+    _create_llm_invocation,
+    _message_to_output,
+    _messages_to_inputs,
 )
 from opentelemetry.instrumentation.agentscope.package import (  # noqa: E402
     get_installed_instrumentation_dependencies,
@@ -77,12 +85,179 @@ def test_v2_tool_result_message_content_is_jsonable():
         ],
     )
 
-    input_message = _message_to_input(msg)
+    [input_message] = _messages_to_inputs(msg)
 
     assert (
         gen_ai_json_dumps([asdict(input_message)])
-        == '[{"role":"assistant","parts":[{"response":[{"content":"sunny","type":"text"}],"id":"tool-call-content","type":"tool_call_response"}]}]'
+        == '[{"role":"tool","parts":[{"response":[{"content":"sunny","type":"text"}],"id":"tool-call-content","type":"tool_call_response"}]}]'
     )
+
+
+def test_v2_cumulative_reply_preserves_round_order_without_mutating_history():
+    msg = Msg(
+        name="agent",
+        role="assistant",
+        content=[
+            ThinkingBlock(thinking="plan one"),
+            ToolCallBlock(id="one", name="lookup", input="{}"),
+            ToolResultBlock(id="one", name="lookup", output="result one"),
+            ThinkingBlock(thinking="plan two"),
+            ToolCallBlock(id="two", name="lookup", input="{}"),
+            ToolResultBlock(id="two", name="lookup", output="result two"),
+            ThinkingBlock(thinking="final reasoning"),
+            TextBlock(text="final answer"),
+        ],
+    )
+    snapshot = msg.model_dump()
+    inputs = _messages_to_inputs([UserMsg("user", "original question"), msg])
+    assert [item.role for item in inputs] == [
+        "user",
+        "assistant",
+        "tool",
+        "assistant",
+        "tool",
+        "assistant",
+    ]
+    assert [
+        part.id
+        for item in inputs
+        if item.role == "tool"
+        for part in item.parts
+    ] == ["one", "two"]
+    assert all(
+        part.type != "tool_call_response"
+        for item in inputs
+        if item.role == "assistant"
+        for part in item.parts
+    )
+    assert [part.content for part in _message_to_output(msg).parts] == [
+        "final answer"
+    ]
+    without_reasoning = _messages_to_inputs(msg, include_reasoning=False)
+    assert not any(
+        part.type == "reasoning"
+        for item in without_reasoning
+        for part in item.parts
+    )
+    assert msg.model_dump() == snapshot
+
+
+@pytest.mark.parametrize("session", [None, "", "  ", "entry-session"])
+def test_v2_entry_identity_precedes_framework_session(session):
+    agent = SimpleNamespace(
+        name="agent", state=SimpleNamespace(session_id="internal")
+    )
+    ctx = baggage.set_baggage("gen_ai.user.id", "entry-user")
+    if session is not None:
+        ctx = baggage.set_baggage("gen_ai.session.id", session, ctx)
+    token = context.attach(ctx)
+    try:
+        invocation = _create_agent_invocation(
+            agent, {"inputs": UserMsg("user", "hello")}
+        )
+        assert invocation.conversation_id == (
+            session if session and session.strip() else "internal"
+        )
+        assert invocation.attributes["gen_ai.user.id"] == "entry-user"
+        assert agent.state.session_id == "internal"
+    finally:
+        context.detach(token)
+
+
+def test_v2_model_formatter_controls_history_reasoning():
+    msg = Msg(
+        name="agent",
+        role="assistant",
+        content=[ThinkingBlock(thinking="history"), TextBlock(text="answer")],
+    )
+    model = SimpleNamespace(
+        model="test", formatter=SimpleNamespace(supports_thinking_input=False)
+    )
+    invocation = _create_llm_invocation(model, {"messages": [msg]})
+    assert [p.type for p in invocation.input_messages[0].parts] == ["text"]
+    model.formatter.supports_thinking_input = True
+    invocation = _create_llm_invocation(model, {"messages": [msg]})
+    assert [p.type for p in invocation.input_messages[0].parts] == [
+        "reasoning",
+        "text",
+    ]
+
+
+@pytest.mark.parametrize("operation", ["agent", "llm"])
+async def test_v2_input_mapping_failure_preserves_one_business_call(
+    instrument, span_exporter, monkeypatch, operation
+):
+    agent = Agent(
+        name="mapping-fault",
+        system_prompt="Reply briefly.",
+        model=_make_model(stream=False),
+    )
+    middleware = _middleware(agent._reply_middlewares)
+    expected = Msg(
+        name="assistant",
+        role="assistant",
+        content=[TextBlock(text="business")],
+    )
+    calls = []
+
+    def broken_mapping(*args, **kwargs):
+        raise ValueError("probe input mapping failure")
+
+    monkeypatch.setattr(_v2_middleware, "_messages_to_inputs", broken_mapping)
+
+    async def reply_handler(**kwargs):
+        calls.append(kwargs)
+        yield expected
+
+    async def model_handler(**kwargs):
+        calls.append(kwargs)
+        return expected
+
+    if operation == "agent":
+        actual = [
+            item
+            async for item in middleware.on_reply(
+                agent, {"inputs": []}, reply_handler
+            )
+        ]
+        assert actual[0] is expected
+    else:
+        actual = await middleware.on_model_call(
+            agent,
+            {"current_model": agent.model, "messages": []},
+            model_handler,
+        )
+        assert actual is expected
+    assert len(calls) == 1
+    assert not span_exporter.get_finished_spans()
+    assert not trace_api.get_current_span().get_span_context().is_valid
+
+
+async def test_v2_standalone_agent_propagates_fallback_session_without_leaking(
+    instrument, span_exporter
+):
+    agent = Agent(
+        name="standalone",
+        system_prompt="Reply briefly.",
+        model=_make_model(stream=False),
+    )
+    middleware = _middleware(agent._reply_middlewares)
+    expected = agent.state.session_id
+    seen = []
+
+    async def reply_handler(**kwargs):
+        seen.append(baggage.get_baggage("gen_ai.session.id"))
+        yield Msg(
+            name="assistant",
+            role="assistant",
+            content=[TextBlock(text="done")],
+        )
+
+    async for _ in middleware.on_reply(agent, {"inputs": []}, reply_handler):
+        assert baggage.get_baggage("gen_ai.session.id") is None
+    assert seen == [expected]
+    assert baggage.get_baggage("gen_ai.session.id") is None
+    assert len(span_exporter.get_finished_spans()) == 1
 
 
 def test_instrumentor_injects_v2_middleware(instrument):
@@ -728,10 +903,12 @@ async def test_v2_reasoning_error_preserves_identity_and_fails_step(
     assert not middleware._reply_states
 
 
+@pytest.mark.parametrize("fault", ["stop", "mapping"])
 async def test_v2_reply_finish_failure_does_not_replace_business_result(
     instrument,
     span_exporter,
     monkeypatch,
+    fault,
 ):
     agent = Agent(
         name="finish_failure_agent",
@@ -750,7 +927,12 @@ async def test_v2_reply_finish_failure_does_not_replace_business_result(
         del args, kwargs
         raise ValueError("probe finish failure")
 
-    monkeypatch.setattr(handler, "stop_invoke_agent", stop_invoke_agent)
+    if fault == "stop":
+        monkeypatch.setattr(handler, "stop_invoke_agent", stop_invoke_agent)
+    else:
+        monkeypatch.setattr(
+            _v2_middleware, "_message_to_output", stop_invoke_agent
+        )
 
     async def reply_handler(**kwargs):
         del kwargs
@@ -1327,7 +1509,7 @@ async def test_v2_skill_viewer_tool_captures_skill_metadata(
     assert tool_span.attributes["gen_ai.skill.version"] == "1.2.3"
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr(record_mode="none")
 async def test_v2_agent_non_streaming_e2e(instrument, span_exporter):
     model = _make_model(stream=False)
     agent = Agent(
@@ -1336,13 +1518,24 @@ async def test_v2_agent_non_streaming_e2e(instrument, span_exporter):
         model=model,
     )
 
-    msg = await agent.reply(UserMsg(name="user", content="Say OK."))
+    token = context.attach(
+        baggage.set_baggage("gen_ai.session.id", "entry-session")
+    )
+    try:
+        msg = await agent.reply(UserMsg(name="user", content="Say OK."))
+    finally:
+        context.detach(token)
 
     assert msg.get_text_content()
-    _assert_agent_and_llm_spans(span_exporter.get_finished_spans())
+    spans = span_exporter.get_finished_spans()
+    _assert_agent_and_llm_spans(spans)
+    for span in spans:
+        assert span.attributes["gen_ai.session.id"] == "entry-session"
+        assert span.attributes["gen_ai.conversation.id"] == "entry-session"
+    assert baggage.get_baggage("gen_ai.session.id") is None
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr(record_mode="none")
 async def test_v2_agent_streaming_e2e(instrument, span_exporter):
     model = _make_model(stream=True)
     agent = Agent(
@@ -1365,7 +1558,7 @@ async def test_v2_agent_streaming_e2e(instrument, span_exporter):
     _assert_agent_and_llm_spans(span_exporter.get_finished_spans())
 
 
-@pytest.mark.vcr()
+@pytest.mark.vcr(record_mode="none")
 async def test_v2_agent_concurrent_e2e(instrument, span_exporter):
     async def call_agent(idx: int):
         agent = Agent(

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_v2_instrumentation.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_v2_instrumentation.py
@@ -39,9 +39,14 @@ from agentscope.message import (  # noqa: E402
     ThinkingBlock,
     ToolCallBlock,
     ToolResultBlock,
+    Usage,
     UserMsg,
 )
-from agentscope.model import ChatResponse, DashScopeChatModel  # noqa: E402
+from agentscope.model import (  # noqa: E402
+    ChatResponse,
+    ChatUsage,
+    DashScopeChatModel,
+)
 from agentscope.tool import ToolResponse  # noqa: E402
 
 from opentelemetry import baggage, context  # noqa: E402
@@ -673,6 +678,109 @@ async def test_v2_streaming_model_call_captures_input_and_output_content(
     assert input_messages[0]["parts"][0]["content"] == "hello"
     assert output_messages[0]["role"] == "assistant"
     assert output_messages[0]["parts"][0]["content"] == "done"
+
+
+@pytest.mark.parametrize("streaming", [False, True])
+@pytest.mark.parametrize("cache_read,cache_creation", [(100, 40), (0, 0)])
+async def test_v2_model_cache_usage(
+    instrument, span_exporter, streaming, cache_read, cache_creation
+):
+    agent = Agent(
+        name="cache_agent",
+        system_prompt="Reply briefly.",
+        model=_make_model(stream=streaming),
+    )
+    middleware = _middleware(agent._model_call_middlewares)
+    response = ChatResponse(
+        content=[TextBlock(text="done")],
+        usage=ChatUsage(
+            input_tokens=200,
+            output_tokens=10,
+            time=0.1,
+            cache_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
+        ),
+        is_last=True,
+    )
+    calls = 0
+
+    async def handler(**kwargs):
+        nonlocal calls
+        calls += 1
+
+        async def chunks():
+            yield ChatResponse(
+                content=[TextBlock(text="partial")],
+                usage=ChatUsage(150, 5, 0.05, cache_input_tokens=75),
+                is_last=False,
+            )
+            yield response
+
+        return chunks() if streaming else response
+
+    result = await middleware.on_model_call(
+        agent,
+        {"current_model": agent.model, "messages": []},
+        handler,
+    )
+    if streaming:
+        chunks = [chunk async for chunk in result]
+        assert chunks[-1] is response
+    else:
+        assert result is response
+    assert calls == 1
+    [span] = _spans_by_operation(span_exporter.get_finished_spans(), "chat")
+    assert (
+        span.attributes["gen_ai.usage.cache_read.input_tokens"] == cache_read
+    )
+    assert (
+        span.attributes["gen_ai.usage.cache_creation.input_tokens"]
+        == cache_creation
+    )
+    assert span.attributes["gen_ai.usage.input_tokens"] == 200
+    assert span.attributes["gen_ai.usage.output_tokens"] == 10
+
+
+@pytest.mark.parametrize("cache_read,cache_creation", [(100, 40), (0, 0)])
+async def test_v2_agent_cache_usage(
+    instrument, span_exporter, cache_read, cache_creation
+):
+    agent = Agent(
+        name="cache_agent",
+        system_prompt="Reply briefly.",
+        model=_make_model(stream=False),
+    )
+    middleware = _middleware(agent._reply_middlewares)
+    expected = Msg(
+        name="assistant",
+        role="assistant",
+        content=[TextBlock(text="done")],
+        usage=Usage(
+            input_tokens=200,
+            output_tokens=10,
+            cache_input_tokens=cache_read,
+            cache_creation_input_tokens=cache_creation,
+        ),
+    )
+
+    async def handler(**kwargs):
+        yield expected
+
+    assert [
+        msg
+        async for msg in middleware.on_reply(agent, {"inputs": []}, handler)
+    ] == [expected]
+    [span] = _spans_by_operation(
+        span_exporter.get_finished_spans(), "invoke_agent"
+    )
+    assert (
+        span.attributes["gen_ai.usage.cache_read.input_tokens"] == cache_read
+    )
+    assert (
+        span.attributes["gen_ai.usage.cache_creation.input_tokens"]
+        == cache_creation
+    )
+    assert span.attributes["gen_ai.usage.input_tokens"] == 200
 
 
 async def test_v2_reply_stream_survives_cross_task_heartbeat(
@@ -1532,6 +1640,8 @@ async def test_v2_agent_non_streaming_e2e(instrument, span_exporter):
     for span in spans:
         assert span.attributes["gen_ai.session.id"] == "entry-session"
         assert span.attributes["gen_ai.conversation.id"] == "entry-session"
+    [llm_span] = _spans_by_operation(spans, "chat")
+    assert llm_span.attributes["gen_ai.usage.cache_read.input_tokens"] == 0
     assert baggage.get_baggage("gen_ai.session.id") is None
 
 
@@ -1556,6 +1666,11 @@ async def test_v2_agent_streaming_e2e(instrument, span_exporter):
         event.__class__.__name__ == "TextBlockDeltaEvent" for event in events
     )
     _assert_agent_and_llm_spans(span_exporter.get_finished_spans())
+
+    [llm_span] = _spans_by_operation(
+        span_exporter.get_finished_spans(), "chat"
+    )
+    assert llm_span.attributes["gen_ai.usage.cache_read.input_tokens"] == 0
 
 
 @pytest.mark.vcr(record_mode="none")

--- a/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_v2_instrumentation.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-agentscope/tests/test_v2_instrumentation.py
@@ -623,8 +623,10 @@ async def test_v2_streaming_model_cancellation_cleans_cross_task_context(
         "chat",
     )
     assert task.cancelled()
-    assert span.status.status_code == StatusCode.ERROR
-    assert span.attributes["error.type"] == "CancelledError"
+    assert span.status.status_code == StatusCode.UNSET
+    assert "error.type" not in span.attributes
+    assert span.attributes["agentscope.cancelled"] is True
+    assert "gen_ai.response.finish_reasons" not in span.attributes
     assert not any(
         "Context detach failed" in record.getMessage()
         or "Failed to detach context" in record.getMessage()
@@ -1138,8 +1140,9 @@ async def test_v2_reply_stream_preserves_cross_task_cancellation(
         "invoke_agent",
     )
     assert len(agent_spans) == 1
-    assert agent_spans[0].status.status_code == StatusCode.ERROR
-    assert agent_spans[0].attributes["error.type"] == "CancelledError"
+    assert agent_spans[0].status.status_code == StatusCode.UNSET
+    assert "error.type" not in agent_spans[0].attributes
+    assert agent_spans[0].attributes["agentscope.cancelled"] is True
 
 
 async def test_v2_tool_acting_hook(instrument, span_exporter):
@@ -1615,6 +1618,107 @@ async def test_v2_skill_viewer_tool_captures_skill_metadata(
         tool_span.attributes["gen_ai.skill.id"] == "workspace:demo:code-review"
     )
     assert tool_span.attributes["gen_ai.skill.version"] == "1.2.3"
+
+
+async def test_v2_tool_cancellation_preserves_exception_and_marks_step(
+    instrument,
+    span_exporter,
+):
+    agent = Agent(
+        name="cancel_tool_agent",
+        system_prompt="Use tools.",
+        model=_make_model(stream=False),
+    )
+    middleware = _middleware(agent._acting_middlewares)
+    cancellation = asyncio.CancelledError("client_stop")
+
+    async def handler(**kwargs):
+        del kwargs
+        raise cancellation
+        yield  # pragma: no cover
+
+    with pytest.raises(asyncio.CancelledError) as caught:
+        async for _ in middleware.on_acting(
+            agent,
+            {
+                "tool_call": SimpleNamespace(
+                    name="lookup", id="one", input="{}"
+                )
+            },
+            handler,
+        ):
+            pass
+    assert caught.value is cancellation
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 2
+    for span in spans:
+        assert span.status.status_code == StatusCode.UNSET
+        assert span.attributes["agentscope.cancelled"] is True
+        assert "error.type" not in span.attributes
+    assert not trace_api.get_current_span().get_span_context().is_valid
+
+
+async def test_v2_real_provider_replay_cancellation(
+    instrument,
+    span_exporter,
+    monkeypatch,
+    vcr,
+):
+    agent = Agent(
+        name="stream_agent",
+        system_prompt="Reply with a short sentence.",
+        model=_make_model(stream=True),
+    )
+    cancellation = asyncio.CancelledError("client_stop")
+
+    async def consume():
+        stream = agent.reply_stream(
+            UserMsg(name="user", content="Say hello in one sentence.")
+        )
+        try:
+            async for _ in stream:
+                pass
+        finally:
+            await stream.aclose()
+
+    # Inject cancellation at a real SDK stream pull, after a replayed chunk.
+    # This preserves the provider/formatter path while making timing deterministic.
+    original_stream = AgentScopeV2Middleware._wrap_model_stream
+
+    async def cancelled_stream(self, result, state):
+        async def cancel_after_chunk():
+            try:
+                yield await result.__anext__()
+                raise cancellation
+            finally:
+                await result.aclose()
+
+        async for chunk in original_stream(self, cancel_after_chunk(), state):
+            yield chunk
+
+    monkeypatch.setattr(
+        AgentScopeV2Middleware, "_wrap_model_stream", cancelled_stream
+    )
+    with vcr.use_cassette(
+        "test_v2_agent_streaming_e2e.yaml", record_mode="none"
+    ):
+        # AgentScope defaults to converting cancellation into an interrupted
+        # ReplyEndEvent rather than raising to the application.
+        await consume()
+    spans = span_exporter.get_finished_spans()
+    assert {s.attributes.get("gen_ai.span.kind") for s in spans} == {
+        "AGENT",
+        "STEP",
+        "LLM",
+    }
+    for span in spans:
+        assert span.status.status_code == StatusCode.UNSET
+        assert span.attributes["agentscope.cancelled"] is True
+        assert "error.type" not in span.attributes
+    [llm] = _spans_by_operation(spans, "chat")
+    assert "gen_ai.response.finish_reasons" not in llm.attributes
+    assert "gen_ai.usage.input_tokens" not in llm.attributes
+    assert not trace_api.get_current_span().get_span_context().is_valid
 
 
 @pytest.mark.vcr(record_mode="none")

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Limit Dream tests to the QwenPaw 2 runtime and verify that QwenPaw 1 and
+  legacy CoPaw retain Entry instrumentation without enabling Dream hooks.
+
 - Propagate the owning agent name during QwenPaw 2 ReMe Dream calls so
   instrumented downstream LLM spans carry `gen_ai.agent.name`. Restore the
   caller context on completion, failure, or cancellation; no agent ID is added.

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Propagate the owning agent name during QwenPaw 2 ReMe Dream calls so
+  instrumented downstream LLM spans carry `gen_ai.agent.name`. Restore the
+  caller context on completion, failure, or cancellation; no agent ID is added.
+
 - Treat `asyncio.CancelledError` as control flow at Entry finalization while
   preserving the original exception. Record `qwenpaw.cancelled` and a bounded
   `qwenpaw.cancellation.reason` from explicit cancellation codes; missing or

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/CHANGELOG.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- Treat `asyncio.CancelledError` as control flow at Entry finalization while
+  preserving the original exception. Record `qwenpaw.cancelled` and a bounded
+  `qwenpaw.cancellation.reason` from explicit cancellation codes; missing or
+  unrecognized reasons are `unknown`, not inferred from partial responses.
+
 ## Version 0.8.0 (2026-07-31)
 
 ### Added

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/README.md
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/README.md
@@ -9,6 +9,27 @@ Compatibility note: CoPaw was renamed to QwenPaw. Installations pinned to
 `AgentRunner.query_handler` as its request entry point; QwenPaw 2 uses
 `Runtime.run`.
 
+## Dream owner attribution
+
+For QwenPaw 2's ReMe memory backend, this plugin scopes
+`gen_ai.agent.name` to the owning agent while `dream()` executes, including
+scheduled and manually triggered Dream calls. It uses the same configured
+name (or `QwenPaw` fallback) as normal conversations and restores the caller's
+context on completion, error, or cancellation. No agent ID or synthetic
+Agent invocation is added.
+
+This is attribution for **already-instrumented LLM calls**, not a new model
+instrumentation layer. Direct model calls outside AgentScope Agent middleware
+need a matching model SDK instrumentor using LoongSuite's GenAI handler; for
+OpenAI-compatible clients, this can be `opentelemetry-instrumentation-openai-v2`.
+The Dream adapter does not install or enable that extra instrumentor, change
+token metric dimensions, or modify memory content.
+
+ReMe versions using internal AgentScope Agents also require the matching
+AgentScope plugin update to preserve Dream ownership across helper Agents.
+Those calls are already collected by AgentScope: enabling an additional SDK
+instrumentor can produce nested, duplicate LLM spans and is not required.
+
 ## Getting Started
 
 QwenPaw is started as its own app (CLI / process entrypoint), not as a library

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/src/opentelemetry/instrumentation/qwenpaw/__init__.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/src/opentelemetry/instrumentation/qwenpaw/__init__.py
@@ -40,6 +40,10 @@ from typing import Any, Collection
 from wrapt import wrap_function_wrapper
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.qwenpaw._dream import (
+    instrument_dream,
+    uninstrument_dream,
+)
 from opentelemetry.instrumentation.qwenpaw.package import (
     _instruments_any,
     get_installed_instrumentation_dependencies,
@@ -79,6 +83,7 @@ class QwenPawInstrumentor(BaseInstrumentor):
             logger_provider=logger_provider,
         )
         runtime_targets = tuple(get_installed_runtime_targets())
+        self._dream_class = None
         if not runtime_targets:
             raise ModuleNotFoundError(
                 "No supported QwenPaw runtime package is installed"
@@ -102,9 +107,14 @@ class QwenPawInstrumentor(BaseInstrumentor):
                 target.method_name,
             )
 
+        if any(target.wrapper_kind == "runtime" for target in runtime_targets):
+            self._dream_class = instrument_dream()
+
     def _uninstrument(self, **kwargs: Any) -> None:
         del kwargs
         self._handler = None
+        uninstrument_dream(getattr(self, "_dream_class", None))
+        self._dream_class = None
         for target in get_installed_runtime_targets():
             try:
                 runtime_module = import_module(target.module_name)

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/src/opentelemetry/instrumentation/qwenpaw/_dream.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/src/opentelemetry/instrumentation/qwenpaw/_dream.py
@@ -1,0 +1,72 @@
+# Copyright The OpenTelemetry Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scope the owning agent name to QwenPaw's background Dream coroutine."""
+
+from importlib import import_module
+
+from wrapt import wrap_function_wrapper
+
+from opentelemetry import baggage, context
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.util.genai import hook_advice
+from opentelemetry.util.genai.handler import _safe_detach
+
+_MODULE = "qwenpaw.agents.memory.reme_light_memory_manager"
+
+
+@hook_advice("qwenpaw", "attach_dream_owner")
+def _attach_owner(instance):
+    # Resolve per invocation, matching normal QwenPaw agent naming and reloads.
+    config = import_module("qwenpaw.config.config")
+    name = config.load_agent_config(instance.agent_id).name or "QwenPaw"
+    if not isinstance(name, str) or not name.strip():
+        return None
+    owner_context = baggage.set_baggage("gen_ai.agent.name", name)
+    # ReMe may create a helper Agent named "default" inside this scope.
+    # Keep the owner override local; it is not an exported span attribute.
+    owner_context = context.set_value(
+        "qwenpaw.dream.agent.name", name, owner_context
+    )
+    return context.attach(owner_context)
+
+
+async def _dream_wrapper(wrapped, instance, args, kwargs):
+    token = _attach_owner(instance)
+    try:
+        return await wrapped(*args, **kwargs)
+    finally:
+        _detach_owner(token)
+
+
+@hook_advice("qwenpaw", "detach_dream_owner")
+def _detach_owner(token):
+    _safe_detach(token)
+
+
+@hook_advice("qwenpaw", "instrument_dream")
+def instrument_dream():
+    # Optional backend: absence must not prevent normal Entry instrumentation.
+    try:
+        module = import_module(_MODULE)
+        cls = module.ReMeLightMemoryManager
+    except (ImportError, AttributeError):
+        return None
+    if not callable(getattr(cls, "dream", None)):
+        return None
+    wrap_function_wrapper(cls, "dream", _dream_wrapper)
+    return cls
+
+
+@hook_advice("qwenpaw", "uninstrument_dream")
+def uninstrument_dream(cls):
+    if cls is not None:
+        unwrap(cls, "dream")

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/src/opentelemetry/instrumentation/qwenpaw/patch.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/src/opentelemetry/instrumentation/qwenpaw/patch.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import timeit
 from dataclasses import dataclass
@@ -39,6 +40,30 @@ from ._entry_utils import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+@hook_advice("qwenpaw", "record_cancellation")
+def _record_cancellation(
+    invocation: EntryInvocation, error: BaseException | None
+) -> None:
+    if (
+        not isinstance(error, asyncio.CancelledError)
+        or invocation.span is None
+    ):
+        return
+    # Only low-cardinality reason codes supplied by the caller are captured.
+    # Never infer a cause from partial output or export arbitrary exception text.
+    reason = error.args[0] if error.args else None
+    if not isinstance(reason, str) or reason not in {
+        "client_stop",
+        "session_closed",
+        "session_reset",
+        "reset",
+        "matrix_orchestration_failed",
+    }:
+        reason = "unknown"
+    invocation.span.set_attribute("qwenpaw.cancelled", True)
+    invocation.span.set_attribute("qwenpaw.cancellation.reason", reason)
 
 
 @dataclass
@@ -183,7 +208,10 @@ def _finish_entry(
     try:
         token = otel_context.attach(state.context)
         invocation.context_token = token
-        if error is None or isinstance(error, GeneratorExit):
+        _record_cancellation(invocation, error)
+        if error is None or isinstance(
+            error, (GeneratorExit, asyncio.CancelledError)
+        ):
             state.handler.stop_entry(invocation)
         else:
             state.handler.fail_entry(

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/requirements.latest.txt
@@ -26,3 +26,7 @@ opentelemetry-instrumentation
 -e instrumentation-loongsuite/loongsuite-instrumentation-agentscope
 -e instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw
 -e util/opentelemetry-util-genai
+
+# Dream calls the model outside AgentScope Agent middleware.
+-e instrumentation-genai/opentelemetry-instrumentation-openai-v2
+vcrpy

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/test_compatibility.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/test_compatibility.py
@@ -18,6 +18,9 @@ from __future__ import annotations
 
 import importlib.metadata
 from types import ModuleType
+from unittest.mock import Mock
+
+import pytest
 
 from opentelemetry.instrumentation.qwenpaw import (
     CoPawInstrumentor,
@@ -92,6 +95,66 @@ def test_runtime_detection_falls_back_to_legacy_copaw(monkeypatch):
     assert QwenPawInstrumentor().instrumentation_dependencies() == (
         "copaw >= 0.1.0, <= 1.0.2",
     )
+
+
+@pytest.mark.parametrize(
+    "version, module_name, method_name, enables_dream",
+    [
+        (
+            _fake_qwenpaw_version,
+            "qwenpaw.app.runner.runner",
+            "AgentRunner.query_handler",
+            False,
+        ),
+        (
+            _fake_copaw_version,
+            "copaw.app.runner.runner",
+            "AgentRunner.query_handler",
+            False,
+        ),
+        (
+            _fake_qwenpaw_v2_version,
+            "qwenpaw.runtime.runtime",
+            "Runtime.run",
+            True,
+        ),
+    ],
+    ids=["qwenpaw-v1", "legacy-copaw", "qwenpaw-v2"],
+)
+def test_dream_hook_only_enabled_for_v2(
+    monkeypatch, version, module_name, method_name, enables_dream
+):
+    monkeypatch.setattr(
+        "opentelemetry.instrumentation.qwenpaw.package.version", version
+    )
+    wrap = Mock()
+    dream = Mock()
+    monkeypatch.setattr(
+        "opentelemetry.instrumentation.qwenpaw.wrap_function_wrapper", wrap
+    )
+    monkeypatch.setattr(
+        "opentelemetry.instrumentation.qwenpaw.instrument_dream", dream
+    )
+    monkeypatch.setattr(
+        "opentelemetry.instrumentation.qwenpaw.ExtendedTelemetryHandler",
+        Mock(),
+    )
+    inst = QwenPawInstrumentor()
+    try:
+        inst._instrument()
+        # Entry instrumentation must remain enabled on every supported runtime.
+        wrap.assert_called_once()
+        assert wrap.call_args.args[:2] == (module_name, method_name)
+        if enables_dream:
+            dream.assert_called_once_with()
+            assert inst._dream_class is dream.return_value
+        else:
+            dream.assert_not_called()
+            assert inst._dream_class is None
+    finally:
+        # No real wrappers were installed; restore the singleton's test state.
+        inst._handler = None
+        inst._dream_class = None
 
 
 def test_uninstrument_handles_qwenpaw_runner(monkeypatch):

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/test_dream.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/test_dream.py
@@ -19,8 +19,20 @@ from types import SimpleNamespace
 import pytest
 
 from opentelemetry import baggage, context
+from opentelemetry.instrumentation.qwenpaw.package import (
+    get_installed_runtime_targets,
+)
 from opentelemetry.util.genai.handler import TelemetryHandler
 from opentelemetry.util.genai.types import LLMInvocation
+
+if not any(
+    target.wrapper_kind == "runtime"
+    for target in get_installed_runtime_targets()
+):
+    # QwenPaw 1 also exposes the ReMe module, but not the Dream runtime API.
+    pytest.skip(
+        "Dream tests require QwenPaw 2 runtime", allow_module_level=True
+    )
 
 memory = pytest.importorskip("qwenpaw.agents.memory.reme_light_memory_manager")
 config = pytest.importorskip("qwenpaw.config.config")

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/test_dream.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/test_dream.py
@@ -1,0 +1,316 @@
+# Copyright The OpenTelemetry Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Dream owner-name propagation without creating an Agent or changing results."""
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from opentelemetry import baggage, context
+from opentelemetry.util.genai.handler import TelemetryHandler
+from opentelemetry.util.genai.types import LLMInvocation
+
+memory = pytest.importorskip("qwenpaw.agents.memory.reme_light_memory_manager")
+config = pytest.importorskip("qwenpaw.config.config")
+
+
+@pytest.fixture
+def manager(monkeypatch):
+    # Run the real dream method without starting ReMe or touching memory files.
+    obj = object.__new__(memory.ReMeLightMemoryManager)
+    obj.agent_id = "owner-a"
+    monkeypatch.setattr(
+        config,
+        "load_agent_config",
+        lambda agent_id: SimpleNamespace(name=agent_id),
+    )
+    return obj
+
+
+@pytest.mark.asyncio
+async def test_dream_name_and_cleanup(
+    manager, monkeypatch, instrument, tracer_provider, span_exporter
+):
+    handler = TelemetryHandler(tracer_provider=tracer_provider)
+    calls = []
+
+    async def job(name, **kwargs):
+        calls.append((name, kwargs))
+        invocation = LLMInvocation(request_model="test-model", provider="test")
+        handler.start_llm(invocation)
+        handler.stop_llm(invocation)
+        return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(manager, "_run_reme_job", job)
+    token = context.attach(baggage.set_baggage("gen_ai.agent.name", "caller"))
+    try:
+        assert await manager.dream(hint="keep this") is None
+        assert baggage.get_baggage("gen_ai.agent.name") == "caller"
+    finally:
+        context.detach(token)
+    assert calls == [
+        ("auto_dream", {"needs_llm": True, "date": "", "hint": "keep this"})
+    ]
+    [span] = span_exporter.get_finished_spans()
+    assert span.attributes["gen_ai.agent.name"] == "owner-a"
+    assert "gen_ai.agent.id" not in span.attributes
+    assert span.attributes["gen_ai.span.kind"] == "LLM"
+    normal = LLMInvocation(request_model="test-model", provider="test")
+    handler.start_llm(normal)
+    handler.stop_llm(normal)
+    assert (
+        "gen_ai.agent.name"
+        not in span_exporter.get_finished_spans()[-1].attributes
+    )
+
+
+@pytest.mark.asyncio
+async def test_dream_uninstrument_restores_method(
+    manager, monkeypatch, instrument
+):
+    async def job(*args, **kwargs):
+        assert baggage.get_baggage("gen_ai.agent.name") is None
+        return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(manager, "_run_reme_job", job)
+    instrument.uninstrument()
+    assert await manager.dream() is None
+
+
+@pytest.mark.asyncio
+async def test_dream_name_reload_and_default(manager, monkeypatch, instrument):
+    profile = SimpleNamespace(name="First")
+    monkeypatch.setattr(config, "load_agent_config", lambda agent_id: profile)
+    names = []
+
+    async def job(*args, **kwargs):
+        names.append(baggage.get_baggage("gen_ai.agent.name"))
+        return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(manager, "_run_reme_job", job)
+    for name in ("First", "Second", ""):
+        profile.name = name
+        await manager.dream()
+    assert names == ["First", "Second", "QwenPaw"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error", [RuntimeError("business"), asyncio.CancelledError("stop")]
+)
+async def test_dream_exception_unchanged(
+    manager, monkeypatch, instrument, error
+):
+    calls = []
+
+    async def job(*args, **kwargs):
+        calls.append(baggage.get_baggage("gen_ai.agent.name"))
+        raise error
+
+    monkeypatch.setattr(manager, "_run_reme_job", job)
+    with pytest.raises(type(error)) as caught:
+        await manager.dream()
+    assert caught.value is error
+    assert calls == ["owner-a"]
+    assert baggage.get_baggage("gen_ai.agent.name") is None
+
+
+@pytest.mark.asyncio
+async def test_dream_internal_agent_preserves_owner(
+    manager, monkeypatch, instrument
+):
+    from opentelemetry.instrumentation.agentscope._v2_middleware import (  # noqa: PLC0415
+        _create_agent_invocation,
+    )
+
+    helper = SimpleNamespace(name="default", model=None, state=None)
+
+    async def job(*args, **kwargs):
+        invocation = _create_agent_invocation(helper, {})
+        assert invocation.agent_name == "owner-a"
+        assert helper.name == "default"
+        return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(manager, "_run_reme_job", job)
+    await manager.dream()
+    assert context.get_value("qwenpaw.dream.agent.name") is None
+    assert _create_agent_invocation(helper, {}).agent_name == "default"
+
+
+@pytest.mark.asyncio
+async def test_dream_concurrency(manager, monkeypatch, instrument):
+    other = object.__new__(memory.ReMeLightMemoryManager)
+    other.agent_id = "owner-b"
+    seen = []
+
+    async def job(*args, **kwargs):
+        before = baggage.get_baggage("gen_ai.agent.name")
+        await asyncio.sleep(0)
+        seen.append((before, baggage.get_baggage("gen_ai.agent.name")))
+        return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(manager, "_run_reme_job", job)
+    monkeypatch.setattr(other, "_run_reme_job", job)
+    await asyncio.gather(manager.dream(), other.dream())
+    assert sorted(seen) == [("owner-a", "owner-a"), ("owner-b", "owner-b")]
+    assert baggage.get_baggage("gen_ai.agent.name") is None
+
+
+@pytest.mark.asyncio
+async def test_dream_config_failure_is_fail_open(
+    manager, monkeypatch, instrument
+):
+    def fail(*args):
+        raise ValueError("config unavailable")
+
+    monkeypatch.setattr(config, "load_agent_config", fail)
+    calls = []
+
+    async def job(*args, **kwargs):
+        calls.append(1)
+        return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(manager, "_run_reme_job", job)
+    assert await manager.dream() is None
+    assert calls == [1]
+    assert baggage.get_baggage("gen_ai.agent.name") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("capture", ["NO_CONTENT", "SPAN_ONLY"])
+@pytest.mark.parametrize("internal_agent", [False, True])
+async def test_dream_real_model_replay(
+    manager,
+    monkeypatch,
+    instrument,
+    tracer_provider,
+    span_exporter,
+    stream,
+    capture,
+    internal_agent,
+):
+    """Reuse real-provider AgentScope cassettes; only ReMe orchestration is stubbed."""
+    import aiohttp.streams  # noqa: PLC0415
+
+    monkeypatch.setattr(
+        aiohttp.streams, "AsyncStreamReaderMixin", object, raising=False
+    )
+    vcr = pytest.importorskip("vcr")
+    from agentscope.credential import DashScopeCredential  # noqa: PLC0415
+    from agentscope.message import Msg, TextBlock  # noqa: PLC0415
+    from agentscope.model import DashScopeChatModel  # noqa: PLC0415
+
+    openai_probe = pytest.importorskip(
+        "opentelemetry.instrumentation.openai_v2"
+    )
+
+    monkeypatch.setenv(
+        "OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", capture
+    )
+    if internal_agent:
+        from opentelemetry.instrumentation.agentscope import (  # noqa: PLC0415
+            AgentScopeInstrumentor,
+        )
+
+        agent_inst = AgentScopeInstrumentor()
+    else:
+        agent_inst = openai_probe.OpenAIInstrumentor()
+    agent_inst.instrument(skip_dep_check=True, tracer_provider=tracer_provider)
+    model = DashScopeChatModel(
+        credential=DashScopeCredential(api_key="test_api_key"),
+        model="qwen-plus",
+        parameters=DashScopeChatModel.Parameters(
+            max_tokens=16, thinking_enable=False
+        ),
+        stream=stream,
+        max_retries=0,
+    )
+    system = (
+        "Reply with a short sentence." if stream else "Reply with exactly: OK"
+    )
+    user = "Say hello in one sentence." if stream else "Say OK."
+
+    async def job(*args, **kwargs):
+        if internal_agent:
+            from agentscope.agent import Agent  # noqa: PLC0415
+            from agentscope.message import UserMsg  # noqa: PLC0415
+
+            helper = Agent(name="default", system_prompt=system, model=model)
+            message = UserMsg(name="user", content=user)
+            if stream:
+                async for _ in helper.reply_stream(message):
+                    pass
+            else:
+                await helper.reply(message)
+            assert helper.name == "default"
+            return SimpleNamespace(success=True)
+        response = await model(
+            [
+                Msg(
+                    name="system",
+                    role="system",
+                    content=[TextBlock(text=system)],
+                ),
+                Msg(name="user", role="user", content=[TextBlock(text=user)]),
+            ]
+        )
+        if stream:
+            async for _ in response:
+                pass
+        return SimpleNamespace(success=True)
+
+    monkeypatch.setattr(manager, "_run_reme_job", job)
+    kind = "streaming" if stream else "non_streaming"
+    cassette = (
+        Path(__file__).resolve().parents[2]
+        / "loongsuite-instrumentation-agentscope/tests/cassettes"
+        / f"test_v2_agent_{kind}_e2e.yaml"
+    )
+
+    def body_match(left, right):
+        assert json.loads(left.body) == json.loads(right.body)
+
+    replay = vcr.VCR(
+        record_mode="none",
+        match_on=[
+            "method",
+            "scheme",
+            "host",
+            "port",
+            "path",
+            "query",
+            "semantic_body",
+        ],
+    )
+    replay.register_matcher("semantic_body", body_match)
+    try:
+        with replay.use_cassette(str(cassette)) as recorded:
+            await manager.dream()
+            assert recorded.all_played
+    finally:
+        agent_inst.uninstrument()
+    [span] = [
+        item
+        for item in span_exporter.get_finished_spans()
+        if item.attributes.get("gen_ai.span.kind") == "LLM"
+    ]
+    assert span.attributes["gen_ai.agent.name"] == "owner-a"
+    assert "gen_ai.agent.id" not in span.attributes
+    assert span.attributes["gen_ai.usage.input_tokens"] > 0
+    assert ("gen_ai.input.messages" in span.attributes) == (
+        capture == "SPAN_ONLY"
+    )
+    assert baggage.get_baggage("gen_ai.agent.name") is None

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/test_runtime_v2.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwenpaw/tests/test_runtime_v2.py
@@ -441,19 +441,36 @@ async def test_runtime_mapping_and_stop_failures_preserve_business_chunks(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reason,expected_reason",
+    [
+        (None, "unknown"),
+        ("client_stop", "client_stop"),
+        ("session_closed", "session_closed"),
+        ("matrix_orchestration_failed", "matrix_orchestration_failed"),
+        ("private free-form data", "unknown"),
+    ],
+)
 async def test_runtime_cancellation_finishes_entry(
     runtime_module,
     tracer_provider,
     span_exporter,
     monkeypatch,
+    reason,
+    expected_reason,
 ):
     started = asyncio.Event()
     never = asyncio.Event()
+    original = []
 
     async def fake_run(self, request):
         del self, request
         started.set()
-        await never.wait()
+        try:
+            await never.wait()
+        except asyncio.CancelledError as error:
+            original.append(error)
+            raise
         yield None
 
     monkeypatch.setattr(runtime_module.Runtime, "run", fake_run)
@@ -462,13 +479,18 @@ async def test_runtime_cancellation_finishes_entry(
         stream = _runtime(runtime_module).run(_request("cancel-session"))
         task = asyncio.create_task(stream.__anext__())
         await started.wait()
-        task.cancel()
-        with pytest.raises(asyncio.CancelledError):
+        task.cancel(reason)
+        with pytest.raises(asyncio.CancelledError) as caught:
             await task
+        assert caught.value is original[0]
     finally:
         instrumentor.uninstrument()
 
-    assert len(_entry_spans(span_exporter)) == 1
+    [entry] = _entry_spans(span_exporter)
+    assert entry.status.status_code.name == "UNSET"
+    assert "error.type" not in entry.attributes
+    assert entry.attributes["qwenpaw.cancelled"] is True
+    assert entry.attributes["qwenpaw.cancellation.reason"] == expected_reason
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

Normalize AgentScope v2 cumulative message history without modifying application state, prefer upstream session/user baggage, and capture cache usage across v1/v2 through a shared helper.

Observe AgentScope v2 and QwenPaw cancellation as control flow: retain the original exception, mark cancelled spans explicitly, and recognize interrupted reply events. Capture only bounded cancellation reason codes actually supplied by the caller; otherwise record unknown. Do not fabricate final LLM usage or stop reasons for interrupted streams.

Attribute QwenPaw 2 Dream LLM calls to the configured owner name, including ReMe helper Agents. Scope ownership per coroutine, restore caller context on exit, and leave application Agent names unchanged. Add no agent ID or synthetic Agent invocation. Direct SDK calls require a matching SDK instrumentor; ReMe AgentScope paths should not enable redundant SDK collection.

QwenPaw Runtime cleanup, receipt parsing and Matrix delivery behavior are unchanged.

Fixes # (N/A)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change

# How Has This Been Tested?

- [x] Fresh-cache `tox -e precommit`
- [x] `tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-agentscope-latest,py312-test-loongsuite-instrumentation-agentscope-oldest -- --vcr-record=none` — 49 v2 and 106 v1 tests
- [x] `tox -c tox-loongsuite.ini -e py312-test-loongsuite-instrumentation-qwenpaw-latest` — 43 passed, 4 v1-only tests skipped; Dream cassettes explicitly use `record_mode="none"`

## Validation Evidence

Direct user-requested implementation; no separate staged spec or issue.

| Area | Status | Evidence |
|---|---|---|
| Regression detection | pass | Pre-change Dream owner assertions fail; strict real-provider cassette replay covers direct SDK and internal Agent paths, streaming/non-streaming and NO_CONTENT/SPAN_ONLY |
| Readiness | pass | Static checks, fresh-cache precommit and package-scoped tests |
| Live runtime matrix | pass | Prior two-environment matrix: 23 requests each, including tools, restored history, streaming, concurrency and cancellation |
| Message boundaries | pass | LLM roles match requests; intermediate reasoning/tool parts excluded from Agent output |
| Cache/session | pass | Real nonzero cache-read attributes and session identity checked in prior cloud readback |
| Cancellation | pass | Actual task cancellations preserve application behavior and expose cancellation attributes without error status |
| Dream ownership | pass | Packaged QwenPaw runtime, manual Console command and real ReMe execution; final run has 25 spans including 8 correctly attributed LLM spans, 5 tools and a persisted memory digest |
| Dream cloud readback | pass | All 25 final-run spans read back; LLM name, input/output and token attributes match local exports; no LLM agent ID added |
| Dream context isolation | pass | Focused concurrency, error/cancellation, config failure, uninstrument and clean sibling checks; ordinary live chat still works |
| SDK overlap | configuration | Redundant SDK instrumentation produced nested duplicate LLM spans; disabled for the live ReMe AgentScope path, not a global suppression fix |
| Earlier cloud readback | partial | Prior updated environment: 23 traces/110 spans; two baseline cancellation traces remain incomplete |
| Content modes | partial | Dream NO_CONTENT/SPAN_ONLY replay plus live SPAN_ONLY; full SPAN_AND_EVENT matrix remains unverified |
| Weaver | blocked | Advisor fails with duplicated definition of local variable tool_call_index |
| Runtime receipt parsing | excluded | Initial Dream calls returned YAML and produced no digest; an explicit JSON hint enabled real extraction/integration without Runtime changes |
| Runtime cleanup | excluded | Existing Runtime-owned GeneratorExit/late-child behavior remains unchanged |

Keep this PR draft. This is not a production rollout, full scheduler/image matrix, or commercial-release validation.

External review remains incomplete because the review tool was blocked and then timed out; the user explicitly approved this draft update without treating that as a review pass.

# Does This PR Require a Core Repo Change?

- [ ] Yes.
- [x] No.

# Checklist:

- [x] Followed the style guidelines of this project
- [x] Changelogs have been updated
- [x] Unit tests have been added
- [ ] Full telemetry matrix completed
