### PR TITLE
fix(genai): remove instrumentation dependency from utilities

### DIFF
--- a/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/conftest.py
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-dashscope/tests/conftest.py
@@ -29,15 +29,15 @@ if "DASHSCOPE_API_KEY" not in os.environ:
     # The actual API key should be set via environment variable before running tests
     os.environ["DASHSCOPE_API_KEY"] = "test_dashscope_api_key"
 
-from opentelemetry.instrumentation._semconv import (
-    OTEL_SEMCONV_STABILITY_OPT_IN,
-    _OpenTelemetrySemanticConventionStability,
-)
 from opentelemetry.instrumentation.dashscope import DashScopeInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
+)
+from opentelemetry.util.genai._configuration import (
+    OTEL_SEMCONV_STABILITY_OPT_IN,
+    is_experimental_mode,
 )
 from opentelemetry.util.genai.environment_variables import (
     OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
@@ -74,7 +74,7 @@ def instrument(tracer_provider):
 def instrument_no_content(tracer_provider):
     """Instrument DashScope SDK with message content capture disabled."""
     # Reset global state to allow environment variable changes to take effect
-    _OpenTelemetrySemanticConventionStability._initialized = False
+    is_experimental_mode.cache_clear()
 
     os.environ.update(
         {
@@ -92,14 +92,14 @@ def instrument_no_content(tracer_provider):
     os.environ.pop(OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, None)
     instrumentor.uninstrument()
     # Reset global state after test
-    _OpenTelemetrySemanticConventionStability._initialized = False
+    is_experimental_mode.cache_clear()
 
 
 @pytest.fixture(scope="function")
 def instrument_with_content(tracer_provider):
     """Instrument DashScope SDK with message content capture enabled."""
     # Reset global state to allow environment variable changes to take effect
-    _OpenTelemetrySemanticConventionStability._initialized = False
+    is_experimental_mode.cache_clear()
 
     os.environ.update(
         {
@@ -117,7 +117,7 @@ def instrument_with_content(tracer_provider):
     os.environ.pop(OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT, None)
     instrumentor.uninstrument()
     # Reset global state after test
-    _OpenTelemetrySemanticConventionStability._initialized = False
+    is_experimental_mode.cache_clear()
 
 
 @pytest.fixture(scope="module")

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.latest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.latest.txt
@@ -20,12 +20,13 @@
 # (opentelemetry-api/sdk/semantic-conventions from CORE_REPO).
 
 # Newest supported versions of external dependencies for qwen-agent tests.
-# numpy / soundfile / python-dateutil: see requirements.oldest.txt
+# numpy / soundfile / python-dateutil / tqdm: see requirements.oldest.txt
 
 qwen-agent>=0.0.20
 numpy>=1.24.0
 soundfile>=0.12.0
 python-dateutil>=2.8.0
+tqdm>=4.27.0
 pytest==7.4.4
 pytest-vcr==1.0.2
 vcrpy>=4.2.0

--- a/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.oldest.txt
+++ b/instrumentation-loongsuite/loongsuite-instrumentation-qwen-agent/tests/requirements.oldest.txt
@@ -13,13 +13,14 @@
 # limitations under the License.
 
 # Oldest supported versions for loongsuite-instrumentation-qwen-agent tests.
-# numpy / soundfile / python-dateutil: not always declared by qwen-agent but
+# numpy / soundfile / python-dateutil / tqdm: not always declared by qwen-agent but
 # required at import time by current qwen_agent modules used in tests.
 
 qwen-agent>=0.0.20
 numpy>=1.24.0
 soundfile>=0.12.0
 python-dateutil>=2.8.0
+tqdm>=4.27.0
 pytest==7.4.4
 pytest-vcr==1.0.2
 vcrpy>=4.2.0

--- a/util/opentelemetry-util-genai/CHANGELOG.md
+++ b/util/opentelemetry-util-genai/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Decouple GenAI configuration and internal HTTP suppression from instrumentation.
+
 - Add multimodal runtime config snapshot and generation-aware uploader hot-reload.
 - Avoid import-time warnings when optional audio dependencies for PCM16-to-WAV conversion are not installed.
 - Guarantee idempotent LLM span/context cleanup when synchronous probe

--- a/util/opentelemetry-util-genai/README.rst
+++ b/util/opentelemetry-util-genai/README.rst
@@ -60,3 +60,12 @@ References
 ----------
 
 * `OpenTelemetry Project <https://opentelemetry.io/>`_
+
+Standalone runtime
+------------------
+
+GenAI utilities do not require ``opentelemetry-instrumentation``. Configure
+``OTEL_SEMCONV_STABILITY_OPT_IN`` before SDK or instrumentor startup; the GenAI
+opt-in is cached on first use. Changing it after startup is unsupported.
+Internal HTTP suppression shares the OpenTelemetry Context suppression key
+with HTTP instrumentors and restores the previous context when the scope exits.

--- a/util/opentelemetry-util-genai/pyproject.toml
+++ b/util/opentelemetry-util-genai/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
 dependencies = [
   # LoongSuite Extension: QwenPaw/CoPaw depend on recent AgentScope
   # releases that require newer OpenTelemetry packages.
-  "opentelemetry-instrumentation >= 0.58b0",
   "opentelemetry-semantic-conventions >= 0.58b0",
   "opentelemetry-api>=1.31.0",
 ]

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_configuration.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_configuration.py
@@ -1,0 +1,31 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from functools import lru_cache
+
+OTEL_SEMCONV_STABILITY_OPT_IN = "OTEL_SEMCONV_STABILITY_OPT_IN"
+
+
+@lru_cache(maxsize=1)
+def is_experimental_mode() -> bool:
+    """Snapshot the GenAI opt-in on first use; configure before SDK startup.
+
+    Keep the instrumentation opt-in token and comma-separated parsing without
+    importing its private initialization state. Runtime changes are unsupported.
+    """
+    return "gen_ai_latest_experimental" in {
+        value.strip()
+        for value in os.environ.get(OTEL_SEMCONV_STABILITY_OPT_IN, "").split(",")
+    }

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_configuration.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_configuration.py
@@ -27,5 +27,7 @@ def is_experimental_mode() -> bool:
     """
     return "gen_ai_latest_experimental" in {
         value.strip()
-        for value in os.environ.get(OTEL_SEMCONV_STABILITY_OPT_IN, "").split(",")
+        for value in os.environ.get(OTEL_SEMCONV_STABILITY_OPT_IN, "").split(
+            ","
+        )
     }

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_multimodal_upload/fs_uploader.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_multimodal_upload/fs_uploader.py
@@ -34,8 +34,6 @@ from typing import Any, Deque, Dict, Optional, Tuple, cast
 import fsspec
 import httpx
 
-from opentelemetry.instrumentation.utils import suppress_http_instrumentation
-
 # LoongSuite Extension: For Python 3.8 Compatibility
 from opentelemetry.util.genai import compatible_hashlib as hashlib
 from opentelemetry.util.genai._multimodal_upload._base import (
@@ -46,6 +44,7 @@ from opentelemetry.util.genai._multimodal_upload.usage_recorder import (
     get_multimodal_usage_recorder,
     provider_label_from_protocol,
 )
+from opentelemetry.util.genai._suppression import suppress_http_instrumentation
 from opentelemetry.util.genai.extended_environment_variables import (
     OTEL_INSTRUMENTATION_GENAI_MULTIMODAL_DOWNLOAD_SSL_VERIFY,
     OTEL_INSTRUMENTATION_GENAI_MULTIMODAL_STORAGE_BASE_PATH,

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_multimodal_upload/pre_uploader.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_multimodal_upload/pre_uploader.py
@@ -41,7 +41,6 @@ from urllib.parse import urlparse
 import httpx
 
 from opentelemetry import trace as ot_trace
-from opentelemetry.instrumentation.utils import suppress_http_instrumentation
 from opentelemetry.trace import SpanContext
 
 # LoongSuite Extension: For Python 3.8 Compatibility
@@ -50,6 +49,7 @@ from opentelemetry.util.genai._multimodal_upload._base import (
     PreUploader,
     PreUploadItem,
 )
+from opentelemetry.util.genai._suppression import suppress_http_instrumentation
 from opentelemetry.util.genai.extended_environment_variables import (
     OTEL_INSTRUMENTATION_GENAI_MULTIMODAL_STORAGE_BASE_PATH,
 )

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_multimodal_upload/presign_client.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_multimodal_upload/presign_client.py
@@ -31,7 +31,7 @@ from typing import Any, Dict, Mapping, Optional
 
 import httpx
 
-from opentelemetry.instrumentation.utils import suppress_http_instrumentation
+from opentelemetry.util.genai._suppression import suppress_http_instrumentation
 
 _logger = logging.getLogger(__name__)
 

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_multimodal_upload/presign_uploader.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_multimodal_upload/presign_uploader.py
@@ -35,7 +35,6 @@ from urllib.parse import urlparse
 
 import httpx
 
-from opentelemetry.instrumentation.utils import suppress_http_instrumentation
 from opentelemetry.util.genai._multimodal_upload._base import (
     PreUploader,
     Uploader,
@@ -57,6 +56,7 @@ from opentelemetry.util.genai._multimodal_upload.usage_recorder import (
     get_multimodal_usage_recorder,
     provider_label_from_protocol,
 )
+from opentelemetry.util.genai._suppression import suppress_http_instrumentation
 from opentelemetry.util.genai.extended_environment_variables import (
     OTEL_INSTRUMENTATION_GENAI_MULTIMODAL_DOWNLOAD_SSL_VERIFY,
     OTEL_INSTRUMENTATION_GENAI_MULTIMODAL_PRESIGN_TIMEOUT,

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_suppression.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/_suppression.py
@@ -1,0 +1,36 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+from typing import Generator
+
+from opentelemetry import context
+from opentelemetry.context import _SUPPRESS_HTTP_INSTRUMENTATION_KEY
+
+
+@contextmanager
+def suppress_http_instrumentation() -> Generator[None, None, None]:
+    """Suppress internal HTTP requests using the key HTTP instrumentors share.
+
+    This private Context key is the compatibility boundary: creating a new key
+    with the same name would not be recognized by existing instrumentors.
+    Robin packaging rewrites both imports to its commercial Context namespace.
+    """
+    token = context.attach(
+        context.set_value(_SUPPRESS_HTTP_INSTRUMENTATION_KEY, True)
+    )
+    try:
+        yield
+    finally:
+        context.detach(token)

--- a/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
+++ b/util/opentelemetry-util-genai/src/opentelemetry/util/genai/utils.py
@@ -19,11 +19,7 @@ from base64 import b64encode
 from functools import partial
 from typing import Any, List, Optional
 
-from opentelemetry.instrumentation._semconv import (
-    _OpenTelemetrySemanticConventionStability,
-    _OpenTelemetryStabilitySignalType,
-    _StabilityMode,
-)
+from opentelemetry.util.genai._configuration import is_experimental_mode
 from opentelemetry.util.genai.environment_variables import (
     OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
     OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT,
@@ -35,26 +31,6 @@ from opentelemetry.util.genai.extended_environment_variables import (  # pylint:
 from opentelemetry.util.genai.types import ContentCapturingMode
 
 logger = logging.getLogger(__name__)
-
-
-def is_experimental_mode() -> bool:
-    # LoongSuite Extension (FIXME): genai-util should not depend on initialization flows in instrumentation packages; otherwise it cannot be delivered as a standalone SDK.
-    # Bypass the initialization logic of instrumentation package by directly accessing the internal state.
-    try:
-        if not _OpenTelemetrySemanticConventionStability._initialized:
-            _OpenTelemetrySemanticConventionStability._initialize()
-    except (ImportError, AttributeError):
-        logger.debug(
-            "Failed to initialize _OpenTelemetrySemanticConventionStability, using default value."
-        )
-        return False
-
-    return (
-        _OpenTelemetrySemanticConventionStability._get_opentelemetry_stability_opt_in_mode(
-            _OpenTelemetryStabilitySignalType.GEN_AI,
-        )
-        is _StabilityMode.GEN_AI_LATEST_EXPERIMENTAL
-    )
 
 
 def get_content_capturing_mode() -> ContentCapturingMode:

--- a/util/opentelemetry-util-genai/test-requirements.txt
+++ b/util/opentelemetry-util-genai/test-requirements.txt
@@ -6,4 +6,3 @@ ossfs>=2021.8.0; platform_python_implementation != "PyPy"
 respx>=0.20.0
 numpy>=1.19.0
 soundfile>=0.10.0
--e opentelemetry-instrumentation

--- a/util/opentelemetry-util-genai/tests/test_decoupled_runtime.py
+++ b/util/opentelemetry-util-genai/tests/test_decoupled_runtime.py
@@ -1,3 +1,17 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import asyncio
 
 import pytest

--- a/util/opentelemetry-util-genai/tests/test_decoupled_runtime.py
+++ b/util/opentelemetry-util-genai/tests/test_decoupled_runtime.py
@@ -1,0 +1,66 @@
+import asyncio
+
+import pytest
+
+from opentelemetry import context
+from opentelemetry.context import _SUPPRESS_HTTP_INSTRUMENTATION_KEY as KEY
+from opentelemetry.util.genai._configuration import is_experimental_mode
+from opentelemetry.util.genai._suppression import suppress_http_instrumentation
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("", False),
+        ("gen_ai", False),
+        ("gen_ai_latest_experimental", True),
+        ("http, gen_ai_latest_experimental ,database", True),
+        ("GEN_AI_LATEST_EXPERIMENTAL", False),
+    ],
+)
+def test_configuration_snapshot(monkeypatch, value, expected):
+    monkeypatch.setenv("OTEL_SEMCONV_STABILITY_OPT_IN", value)
+    is_experimental_mode.cache_clear()
+    try:
+        assert is_experimental_mode() is expected
+        monkeypatch.setenv("OTEL_SEMCONV_STABILITY_OPT_IN", "changed")
+        assert is_experimental_mode() is expected
+    finally:
+        is_experimental_mode.cache_clear()
+
+
+def test_nested_exception_restores_context():
+    previous = context.get_current()
+    with suppress_http_instrumentation():
+        assert context.get_value(KEY) is True
+        with pytest.raises(ValueError):
+            with suppress_http_instrumentation():
+                raise ValueError("download failed")
+        assert context.get_value(KEY) is True
+    assert context.get_current() is previous
+
+
+def test_async_cancellation_and_isolation():
+    async def run():
+        entered = asyncio.Event()
+        restored = []
+
+        async def download():
+            previous = context.get_current()
+            try:
+                with suppress_http_instrumentation():
+                    entered.set()
+                    await asyncio.Future()
+            finally:
+                restored.append(context.get_current() is previous)
+
+        task = asyncio.create_task(download())
+        await entered.wait()
+        assert not context.get_value(KEY)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert restored == [True]
+        assert not context.get_value(KEY)
+
+    asyncio.run(run())

--- a/util/opentelemetry-util-genai/tests/test_events_options.py
+++ b/util/opentelemetry-util-genai/tests/test_events_options.py
@@ -16,9 +16,9 @@ import os
 import unittest
 from unittest.mock import patch
 
-from opentelemetry.instrumentation._semconv import (
+from opentelemetry.util.genai._configuration import (
     OTEL_SEMCONV_STABILITY_OPT_IN,
-    _OpenTelemetrySemanticConventionStability,
+    is_experimental_mode,
 )
 from opentelemetry.util.genai.environment_variables import (
     OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
@@ -41,8 +41,8 @@ def patch_env_vars(stability_mode, content_capturing, emit_event):
         )
         def wrapper(*args, **kwargs):
             # Reset state.
-            _OpenTelemetrySemanticConventionStability._initialized = False
-            _OpenTelemetrySemanticConventionStability._initialize()
+            is_experimental_mode.cache_clear()
+            is_experimental_mode()
             return test_case(*args, **kwargs)
 
         return wrapper

--- a/util/opentelemetry-util-genai/tests/test_extended_handler.py
+++ b/util/opentelemetry-util-genai/tests/test_extended_handler.py
@@ -26,10 +26,6 @@ from opentelemetry import baggage as baggage_api
 from opentelemetry import context as context_api
 from opentelemetry import trace
 from opentelemetry.baggage import get_all as get_all_baggage
-from opentelemetry.instrumentation._semconv import (
-    OTEL_SEMCONV_STABILITY_OPT_IN,
-    _OpenTelemetrySemanticConventionStability,
-)
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs.export import (  # pylint: disable=no-name-in-module
     InMemoryLogRecordExporter,
@@ -50,6 +46,10 @@ from opentelemetry.semconv.attributes import (
     server_attributes as ServerAttributes,
 )
 from opentelemetry.trace.status import StatusCode
+from opentelemetry.util.genai._configuration import (
+    OTEL_SEMCONV_STABILITY_OPT_IN,
+    is_experimental_mode,
+)
 from opentelemetry.util.genai._multimodal_processing import (
     MultimodalProcessingMixin,
     _MultimodalAsyncTask,
@@ -133,8 +133,8 @@ def patch_env_vars(
         @patch.dict(os.environ, env_vars)
         def wrapper(*args, **kwargs):
             # Reset state.
-            _OpenTelemetrySemanticConventionStability._initialized = False
-            _OpenTelemetrySemanticConventionStability._initialize()
+            is_experimental_mode.cache_clear()
+            is_experimental_mode()
             return test_case(*args, **kwargs)
 
         return wrapper

--- a/util/opentelemetry-util-genai/tests/test_extended_memory.py
+++ b/util/opentelemetry-util-genai/tests/test_extended_memory.py
@@ -18,9 +18,9 @@ from typing import Any, Mapping
 from unittest.mock import patch
 
 from opentelemetry import trace
-from opentelemetry.instrumentation._semconv import (
+from opentelemetry.util.genai._configuration import (
     OTEL_SEMCONV_STABILITY_OPT_IN,
-    _OpenTelemetrySemanticConventionStability,
+    is_experimental_mode,
 )
 
 # Backward compatibility for InMemoryLogExporter -> InMemoryLogRecordExporter rename
@@ -97,8 +97,8 @@ def patch_env_vars(stability_mode, content_capturing=None, emit_event=None):
         @patch.dict(os.environ, env_vars)
         def wrapper(*args, **kwargs):
             # Reset state.
-            _OpenTelemetrySemanticConventionStability._initialized = False
-            _OpenTelemetrySemanticConventionStability._initialize()
+            is_experimental_mode.cache_clear()
+            is_experimental_mode()
             return test_case(*args, **kwargs)
 
         return wrapper

--- a/util/opentelemetry-util-genai/tests/test_http_suppression_integration.py
+++ b/util/opentelemetry-util-genai/tests/test_http_suppression_integration.py
@@ -1,14 +1,24 @@
+# Copyright The OpenTelemetry Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import asyncio
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
+import httpx
 import pytest
 
-pytest.importorskip("opentelemetry.instrumentation.httpx")
-
-import httpx
-
-from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
@@ -18,14 +28,17 @@ from opentelemetry.util.genai._suppression import suppress_http_instrumentation
 
 
 def test_http_plugin_recognizes_suppression():
+    httpx_instrumentation = pytest.importorskip(
+        "opentelemetry.instrumentation.httpx"
+    )
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
-    plugin = HTTPXClientInstrumentor()
+    plugin = httpx_instrumentation.HTTPXClientInstrumentor()
     plugin.instrument(tracer_provider=provider)
 
     class Handler(BaseHTTPRequestHandler):
-        def do_GET(self):
+        def do_GET(self):  # pylint: disable=invalid-name
             self.send_response(200)
             self.end_headers()
 

--- a/util/opentelemetry-util-genai/tests/test_http_suppression_integration.py
+++ b/util/opentelemetry-util-genai/tests/test_http_suppression_integration.py
@@ -1,0 +1,65 @@
+import asyncio
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+pytest.importorskip("opentelemetry.instrumentation.httpx")
+
+import httpx
+
+from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.util.genai._suppression import suppress_http_instrumentation
+
+
+def test_http_plugin_recognizes_suppression():
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    plugin = HTTPXClientInstrumentor()
+    plugin.instrument(tracer_provider=provider)
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.end_headers()
+
+        def log_message(self, *args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{server.server_port}"
+    try:
+        with httpx.Client(trust_env=False) as client:
+            with suppress_http_instrumentation():
+                assert client.get(url + "/internal").status_code == 200
+            assert len(exporter.get_finished_spans()) == 0
+            client.get(url + "/business")
+            assert len(exporter.get_finished_spans()) == 1
+
+        async def run():
+            async with httpx.AsyncClient(trust_env=False) as client:
+                try:
+                    with suppress_http_instrumentation():
+                        await client.get(url + "/internal")
+                        raise ValueError("failed processing")
+                except ValueError:
+                    pass
+                assert len(exporter.get_finished_spans()) == 1
+                await client.get(url + "/business")
+                assert len(exporter.get_finished_spans()) == 2
+
+        asyncio.run(run())
+    finally:
+        plugin.uninstrument()
+        provider.shutdown()
+        server.shutdown()
+        server.server_close()
+        thread.join()

--- a/util/opentelemetry-util-genai/tests/test_utils.py
+++ b/util/opentelemetry-util-genai/tests/test_utils.py
@@ -19,10 +19,6 @@ from typing import Any, Mapping, Optional
 from unittest.mock import patch
 
 from opentelemetry import trace
-from opentelemetry.instrumentation._semconv import (
-    OTEL_SEMCONV_STABILITY_OPT_IN,
-    _OpenTelemetrySemanticConventionStability,
-)
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs.export import (
     InMemoryLogRecordExporter,
@@ -42,6 +38,10 @@ from opentelemetry.semconv.attributes import (
 )
 from opentelemetry.semconv.schemas import Schemas
 from opentelemetry.trace.status import StatusCode
+from opentelemetry.util.genai._configuration import (
+    OTEL_SEMCONV_STABILITY_OPT_IN,
+    is_experimental_mode,
+)
 from opentelemetry.util.genai.environment_variables import (
     OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT,
     OTEL_INSTRUMENTATION_GENAI_EMIT_EVENT,
@@ -78,8 +78,8 @@ def patch_env_vars(stability_mode, content_capturing, emit_event):
         )
         def wrapper(*args, **kwargs):
             # Reset state.
-            _OpenTelemetrySemanticConventionStability._initialized = False
-            _OpenTelemetrySemanticConventionStability._initialize()
+            is_experimental_mode.cache_clear()
+            is_experimental_mode()
             return test_case(*args, **kwargs)
 
         return wrapper

--- a/uv.lock
+++ b/uv.lock
@@ -3982,7 +3982,6 @@ name = "opentelemetry-util-genai"
 source = { editable = "util/opentelemetry-util-genai" }
 dependencies = [
     { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions" },
 ]
 
@@ -4009,7 +4008,6 @@ requires-dist = [
     { name = "httpx", marker = "extra == 'multimodal-upload'" },
     { name = "numpy", marker = "extra == 'audio-conversion'" },
     { name = "opentelemetry-api", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-api&branch=main" },
-    { name = "opentelemetry-instrumentation", editable = "opentelemetry-instrumentation" },
     { name = "opentelemetry-semantic-conventions", git = "https://github.com/open-telemetry/opentelemetry-python?subdirectory=opentelemetry-semantic-conventions&branch=main" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
     { name = "soundfile", marker = "extra == 'audio-conversion'" },


### PR DESCRIPTION
# Description

Remove the GenAI utility package's runtime dependency on `opentelemetry-instrumentation`. Previously, installing the utility alone could also install instrumentation and its transitive wrapt dependency.

Cache the existing GenAI semantic-convention opt-in on first use without accessing instrumentation's private initialization state. Centralize internal HTTP suppression using the existing OpenTelemetry Context key, including presigned upload paths, and restore the previous context on scope exit. The private Context key remains a compatibility boundary. Configure the opt-in before SDK/instrumentor startup; runtime changes are unsupported.

## Type of change

- [x] Bug fix
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `python -m pytest util/opentelemetry-util-genai/tests -q`: 439 passed, 2 skipped in the standalone environment (OSS credentials absent; optional HTTPX instrumentation absent).
- [x] `python -m pytest util/opentelemetry-util-genai/tests/test_decoupled_runtime.py -q`: 7 passed against an installed wheel without instrumentation or wrapt.
- [x] Local HTTP server and actual HTTPX instrumentation: internal requests produce no HTTP spans; later synchronous/asynchronous business requests produce spans, including after an exception.
- [x] Wheel metadata and imports: no instrumentation requirement; all four multimodal modules import without instrumentation/wrapt.
- [x] `git diff --check` and focused Ruff checks.
- [x] `tox -e precommit`: all hooks passed after applying formatting and the dependency lock update.
- [x] `tox -c tox-loongsuite.ini -e py312-test-util-genai`: 439 passed, 2 skipped.

## Validation Evidence

The user approved the dependency-decoupling design and implementation. This PR changes shared configuration, internal HTTP suppression, dependency metadata, documentation and tests; it does not change provider wrappers or GenAI span schemas.

- Static readiness: pass (checker reports no changed instrumentation plugin directory).
- Context nesting, exception cleanup and asynchronous cancellation/isolation: pass.
- HTTP instrumentation interoperability: pass.
- Live model streaming, agent/tool/ReAct and tool-heavy scenarios: N/A for this dependency-only change; no provider execution lifecycle is modified.
- Weaver: not run; no GenAI telemetry schema change.
- Independent review: pending.
- GitHub CI: pending.

This PR remains draft pending independent review and GitHub CI.

# Does This PR Require a Core Repo Change?

- [x] No.

# Checklist:

- [x] Changelogs have been updated
- [x] Unit tests have been added
- [x] Documentation has been updated
- [ ] All submission checks and review are complete
